### PR TITLE
Update OAPIP-specific link relations to be URIs to be compliant with OGC-NA policies.

### DIFF
--- a/core/abstract_tests/core/ATS_conformance-op.adoc
+++ b/core/abstract_tests/core/ATS_conformance-op.adoc
@@ -4,7 +4,7 @@
 ^|*Abstract Test {counter:ats-id}* |*/conf/core/conformance-op*
 ^|Test Purpose |Validate that a Conformance Declaration can be retrieved from the expected location.
 ^|Requirement |<<req_core_conformance-op,/req/core/conformance-op>>
-^|Test Method |. Construct a path for each "conformance" link on the landing page as well as for the {root}/conformance path.
+^|Test Method |. Construct a path for each "rel=http://www.opengis.net/def/rel/ogc/1.0/conformance" link on the landing page as well as for the {root}/conformance path.
 . Issue an HTTP GET request on each path
 . Validate the contents of the returned document using test <<ats_core_conformance-success,/conf/core/conformance-success>>.
 |===

--- a/core/abstract_tests/core/ATS_landingpage-success.adoc
+++ b/core/abstract_tests/core/ATS_landingpage-success.adoc
@@ -10,7 +10,7 @@
 
 .. Validate that the landing page includes a "service-desc" and/or "service-doc" link to an API Definition.
 
-.. Validate that the landing page includes a "conformance" link to the conformance class declaration.
+.. Validate that the landing page includes a "http://www.opengis.net/def/rel/ogc/1.0/conformance" link to the conformance class declaration.
 
 .. Validate that the landing page includes a "data" link to the Feature contents.
 |===

--- a/core/clause_5_conventions.adoc
+++ b/core/clause_5_conventions.adoc
@@ -32,17 +32,19 @@ The following <<link-relations,registered link relation types>> are used in this
 
 In addition the following link relation types are used for which no applicable registered link relation type could be identified.
 
-* **conformance**: Refers to a resource that identifies the specifications that the link's context conforms to.
+* **http://www.opengis.net/def/rel/ogc/1.0/conformance**: Refers to a resource that identifies the specifications that the link's context conforms to.
 
-* **exceptions**: The target URI points to exceptions of a failed process.
+* **http://www.opengis.net/def/rel/ogc/1.0/exceptions**: The target URI points to exceptions of a failed process.
 
-* **execute**: The target URI points to the execution endpoint of the server.
+* **http://www.opengis.net/def/rel/ogc/1.0/execute**: The target URI points to the execution endpoint of the server.
 
-* **process-desc**: The target URI points to a specific process description.
+* **http://www.opengis.net/def/rel/ogc/1.0/job-list**: The target URI points to the list of jobs.
 
-* **processes**: The target URI points to the list of processes the API offers.
+* **http://www.opengis.net/def/rel/ogc/1.0/process-desc**: The target URI points to a specific process description.
 
-* **results**: The target URI points to the results of a job.
+* **http://www.opengis.net/def/rel/ogc/1.0/processes**: The target URI points to the list of processes the API offers.
+
+* **http://www.opengis.net/def/rel/ogc/1.0/results**: The target URI points to the results of a job.
 
 Each resource representation includes an array of links. Implementations are free to add additional links for all resources provided by the API. 
 

--- a/core/clause_5_conventions.adoc
+++ b/core/clause_5_conventions.adoc
@@ -40,8 +40,6 @@ In addition the following link relation types are used for which no applicable r
 
 * **http://www.opengis.net/def/rel/ogc/1.0/job-list**: The target URI points to the list of jobs.
 
-* **http://www.opengis.net/def/rel/ogc/1.0/process-desc**: The target URI points to a specific process description.
-
 * **http://www.opengis.net/def/rel/ogc/1.0/processes**: The target URI points to the list of processes the API offers.
 
 * **http://www.opengis.net/def/rel/ogc/1.0/results**: The target URI points to the results of a job.

--- a/core/examples/json/JobList.json
+++ b/core/examples/json/JobList.json
@@ -29,7 +29,7 @@
 		},
 		{
 		    "href": "http://processing.example.org/oapi-p/jobs/0cf773a5-282a-4e23-96cc-f5dab18123e5/results",
-		    "rel": "results",
+		    "rel": "http://www.opengis.net/def/rel/ogc/1.0/results",
 		    "type": "application/json",
 		    "hreflang": "en",
 		    "title": "Job result"
@@ -51,7 +51,7 @@
 		},
 		{
 		    "href": "http://processing.example.org/oapi-p/jobs/63aadd9c-c0e5-4a7f-80f0-228dbb158f09/results",
-		    "rel": "exceptions",
+		    "rel": "http://www.opengis.net/def/rel/ogc/1.0/exceptions",
 		    "type": "application/json",
 		    "hreflang": "en",
 		    "title": "Job exception"

--- a/core/examples/json/LandingPage.json
+++ b/core/examples/json/LandingPage.json
@@ -24,19 +24,19 @@
 	},
 	{
 		"href": "http://processing.example.org/oapi-p/conformance",
-		"rel": "conformance",
+		"rel": "http://www.opengis.net/def/rel/ogc/1.0/conformance",
 		"type": "application/json",
 		"title": "OGC API - Processes conformance classes implemented by this server"
 	},
 	{
 		"href": "http://processing.example.org/oapi-p/processes",
-		"rel": "processes",
+		"rel": "http://www.opengis.net/def/rel/ogc/1.0/processes",
 		"type": "application/json",
 		"title": "Metadata about the processes"
 	},
 	{
 		"href": "http://processing.example.org/oapi-p/jobs",
-		"rel": "jobs",
+		"rel": "http://www.opengis.net/def/rel/ogc/1.0/jobs-list",
 		"title": "The endpoint for job monitoring"
 	}]
 }

--- a/core/examples/json/ProcessDescription.json
+++ b/core/examples/json/ProcessDescription.json
@@ -320,7 +320,7 @@
   "links": [
     {
       "href": "https://processing.example.org/oapi-p/processes/EchoProcess/execution",
-      "rel": "execute",
+      "rel": "http://www.opengis.net/def/rel/ogc/1.0/execute",
       "title": "Execute endpoint"
     }
   ]

--- a/core/examples/json/ProcessList.json
+++ b/core/examples/json/ProcessList.json
@@ -9,7 +9,7 @@
           {
             "href": "https://processing.example.org/oapi-p/processes/EchoProcess",
             "type": "application/json",
-            "rel": "process-desc",
+            "rel": "self",
             "title": "process description"
           }
         ]

--- a/core/openapi/responses/LandingPage.yaml
+++ b/core/openapi/responses/LandingPage.yaml
@@ -2,7 +2,7 @@ description: |-
   The landing page provides links to the API definition
   (link relations `service-desc` and `service-doc`),
   the Conformance declaration (path `/conformance`,
-  link relation `conformance`), and to other resources.
+  link relation `http://www.opengis.net/def/rel/ogc/1.0/conformance`), and to other resources.
 content:
   application/json:
     schema:

--- a/core/recommendations/job-list/REC_job-list-landing-page.adoc
+++ b/core/recommendations/job-list/REC_job-list-landing-page.adoc
@@ -5,5 +5,5 @@
 
 A link to the following resource SHOULD be added to the API landing page:
 
-/jobs (relation type 'job-list')
+/jobs (relation type 'http://www.opengis.net/def/rel/ogc/1.0/job-list')
 |===

--- a/core/requirements/core/REQ_landingpage-success.adoc
+++ b/core/requirements/core/REQ_landingpage-success.adoc
@@ -10,6 +10,6 @@ The content of that response SHALL be based upon the OpenAPI 3.0 schema link:htt
 and include at least links to the following resources:
 
 * the API definition (relation type 'service-desc' or 'service-doc')
-* `/conformance` (relation type 'conformance')
-* `/processes` (relation type 'processes')
+* `/conformance` (relation type 'http://www.opengis.net/def/rel/ogc/1.0/conformance')
+* `/processes` (relation type 'http://www.opengis.net/def/rel/ogc/1.0/processes')
 |===


### PR DESCRIPTION
Update all OAPIR-specific link relations to use the pattern `http://www.opengis.net/def/rel/ogc/1.0/{rel}`.  Eventually these will be
registered with the OGC-NA. 