### PR TITLE
results.yaml: Removed array (#219)

### DIFF
--- a/core/openapi/schemas/results.yaml
+++ b/core/openapi/schemas/results.yaml
@@ -1,6 +1,3 @@
 additionalProperties:
   oneOf:
     - $ref: "inlineOrRefData.yaml"
-    - type: array
-      items:
-        $ref: "inlineOrRefData.yaml"


### PR DESCRIPTION
There is no multiplicity for outputs. Arrays can be returned by defining the schema in the output description as such.