### PR TITLE
Remove default value for job control options.  

### DIFF
--- a/core/openapi/schemas/jobControlOptions.yaml
+++ b/core/openapi/schemas/jobControlOptions.yaml
@@ -2,5 +2,3 @@ type: string
 enum:
   - sync-execute
   - async-execute
-default:
-  - sync-execute


### PR DESCRIPTION
In the OGC process description the supported execution modes must be explicitly listed
so there is no need for a default.