### PR TITLE
Oppsie!  Forgot to make processID mandatory if the server supports the Job Lists conformance class.

### DIFF
--- a/core/abstract_tests/ATS_class_job-list.adoc
+++ b/core/abstract_tests/ATS_class_job-list.adoc
@@ -27,6 +27,8 @@ include::job-list/ATS_jl-links.adoc[]
 
 include::job-list/ATS_type-response.adoc[]
 
+include::job-list/ATS_processid-mandatory.adoc[]
+
 include::job-list/ATS_processid-response.adoc[]
 
 include::job-list/ATS_status-response.adoc[]

--- a/core/abstract_tests/job-list/ATS_datetime-response.adoc
+++ b/core/abstract_tests/job-list/ATS_datetime-response.adoc
@@ -3,7 +3,7 @@
 |===
 ^|*Abstract Test {counter:ats-id}* |*/conf/job-list/datetime-response*
 ^|Test Purpose |Validate that the `datetime` query parameter is processed correctly.
-^|Requirement |<<req_job-list_limit-response,/req/job-list/limit-response>>
+^|Requirement |<<req_job-list_datetime-response,/req/job-list/datetime-response>>
 ^|Test Method |. Get a list of jobs as per test <<ats_job-list_job-list-op,/conf/job-list/job-list-op>> and append the `datatime` query parameter to the request.
 . Inspect the value of the `created` (see: https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/core/openapi/schemas/statusInfo.yaml[statusInfo.yaml]) property for each job listed in the response.
 . Verify that the value of the `created` temporally intersects with the value specified for the `datetime` query parameter.

--- a/core/abstract_tests/job-list/ATS_duration-response.adoc
+++ b/core/abstract_tests/job-list/ATS_duration-response.adoc
@@ -3,7 +3,7 @@
 |===
 ^|*Abstract Test {counter:ats-id}* |*/conf/job-list/duration-response*
 ^|Test Purpose |Validate that the `minDuration` and `maxDuration` query parameter are processed correctly.
-^|Requirement |<<req_job-list_limit-response,/req/job-list/limit-response>>
+^|Requirement |<<req_job-list_duration-response,/req/job-list/duration-response>>
 ^|Test Method |. Get a list of jobs as per test <<ats_job-list_job-list-op,/conf/job-list/job-list-op>> and append the `minDuration` query parameter to the request.
 . Compute the duration of each job listed in the response document as per requirements <<req_job-list_duration-response,/req/job-list/status-response, E or F>> depending on the current status of the job.
 . Verify that the computed duration of each job listed in the response is at least as long as the specified value of the `minDuration` query parameter.

--- a/core/abstract_tests/job-list/ATS_processid-mandatory.adoc
+++ b/core/abstract_tests/job-list/ATS_processid-mandatory.adoc
@@ -4,6 +4,6 @@
 ^|*Abstract Test {counter:ats-id}* |*/conf/job-list/processID-mandatory*
 ^|Test Purpose |Validate that the `processID` property is present in every job.
 ^|Requirement |<<req_job-list_processID-mandatory,/req/job-list/processID-mandatory>>
-^|Test Method |. Get a list of jobs as per test <<ats_job-list_job-list-op,/conf/job-list/job-list-op>> and append the `datatime` query parameter to the request.
+^|Test Method |. Get a list of jobs as per test <<ats_job-list_job-list-op,/conf/job-list/job-list-op>>.
 . Verify that each job includes a `processID` property.
 |===

--- a/core/abstract_tests/job-list/ATS_processid-mandatory.adoc
+++ b/core/abstract_tests/job-list/ATS_processid-mandatory.adoc
@@ -1,0 +1,9 @@
+[[ats_job-list_processid-mandatory]]
+[width="90%",cols="2,6a"]
+|===
+^|*Abstract Test {counter:ats-id}* |*/conf/job-list/processID-mandatory*
+^|Test Purpose |Validate that the `processID` property is present in every job.
+^|Requirement |<<req_job-list_processID-mandatory,/req/job-list/processID-mandatory>>
+^|Test Method |. Get a list of jobs as per test <<ats_job-list_job-list-op,/conf/job-list/job-list-op>> and append the `datatime` query parameter to the request.
+. Verify that each job includes a `processID` property.
+|===

--- a/core/clause_10_job_list.adoc
+++ b/core/clause_10_job_list.adoc
@@ -1,6 +1,8 @@
 [[Job_list]]
 == Requirements Class "Job list"
 
+== Overview 
+
 This requirement class specifies how to retrieve a job list from the API.
 
 include::requirements/requirements_class_job-list.adoc[]
@@ -18,6 +20,8 @@ include::requirements/job-list/REQ_type-def.adoc[]
 include::requirements/job-list/REQ_type-response.adoc[]
 
 ==== Parameter `processID`
+
+include::requirements/job-list/REQ_processid-mandatory.adoc[]
 
 include::requirements/job-list/REQ_processid-def.adoc[]
 include::requirements/job-list/REQ_processid-response.adoc[]

--- a/core/recommendations/core/REC_job-status.adoc
+++ b/core/recommendations/core/REC_job-status.adoc
@@ -3,6 +3,7 @@
 |===
 |Recommendation {counter:rec-id} |/rec/core/job-status +
 
+^|A |Servers SHOULD set the value of the `processID` field if it is known.
 ^|A |Servers SHOULD set the value of the `created` field when a job has been accepted and queued for execution.
 ^|B |Servers SHOULD set the value of the `started` field when a job begins execution and is consuming compute resources.
 ^|C |Servers SHOULD set the value of the `finished` field when the execution of a job has completed and the process is no longer consuming compute resources.

--- a/core/requirements/job-list/REQ_processid-mandatory.adoc
+++ b/core/requirements/job-list/REQ_processid-mandatory.adoc
@@ -1,0 +1,6 @@
+[[req_job-list_processID-mandatory]]
+[width="90%",cols="2,6a"]
+|===
+^|*Requirement {counter:req-id}* |*/req/job-list/processID-mandatory*
+^|A |If the server supports this conformance class, the optional `processID` property in the https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/core/openapi/schemas/statusInfo.yaml[statusInfo.yaml] schema SHALL be mandatory.
+|===


### PR DESCRIPTION
If the server supports the Job Lists conformance class then the processID property should be mandatory.  Forgot to make this change when I was adding the query parameters to the `/jobs` endpoint.  Fixed now.