### PR TITLE
fix required 'value' for 'measurement' in example process description

### DIFF
--- a/core/examples/json/ProcessDescription.json
+++ b/core/examples/json/ProcessDescription.json
@@ -30,7 +30,7 @@
       "schema": {
         "type": "object",
         "required": [
-          "value",
+          "measurement",
           "uom"
         ],
         "properties": {
@@ -144,7 +144,7 @@
           },
           {
             "$ref": "../../openapi/schemas/bbox.yaml"
-          }  
+          }
         ]
       }
     },
@@ -211,7 +211,7 @@
       "schema": {
         "type": "object",
         "required": [
-          "value",
+          "measurement",
           "uom"
         ],
         "properties": {


### PR DESCRIPTION
Required field did not make sense for an input as :

```json
{ 
  "inputs": {
    "measureInput": {
      "value": {
        "measurement": 123,
        "uom": "m",
      }
    }
  }
}
