### PR TITLE
Clarify that a job dismiss should not touch results that perhaps have…

### DIFF
--- a/core/sections/clause_14_dismiss.adoc
+++ b/core/sections/clause_14_dismiss.adoc
@@ -2,7 +2,7 @@
 [[Dismiss]]
 == Requirements Class "Dismiss"
 
-The Dismiss requirement class specifies how to dismiss a job. Dismiss can be seen as cancelling a running job or removing artifacts of a finished job.
+The Dismiss requirement class specifies how to dismiss a job. Dismiss can be seen as cancelling a running job or removing internal artifacts of a finished job.
 
 include::../requirements/requirements_class_dismiss.adoc[]
 


### PR DESCRIPTION
… been staged-out to external components

There has been a discussion in the EOEPCA project about whether to delete (or not) the processing results of a process when a dismiss operation is called. It feels natural that the files that have been stored on the processing server should be deleted on dismiss, but in the case that the processing results have been stored on an external storage (e.g. an s3 bucket) and perhaps have been registered to an external catalogue, the dismiss call should not delete those assets by default.
I am proposing this minor change to make this a bit more clear.