### PR TITLE
Use application/problem+json as specified in section 6.1 of the IETF RFC 7807

### DIFF
--- a/core/openapi/responses/InvalidParameter.yaml
+++ b/core/openapi/responses/InvalidParameter.yaml
@@ -1,6 +1,6 @@
 description: A query parameter has an invalid value.
 content:
-  application/json:
+  application/problem+json:
     schema:
       $ref: "../schemas/exception.yaml"
   text/html:

--- a/core/openapi/responses/NotAllowed.yaml
+++ b/core/openapi/responses/NotAllowed.yaml
@@ -1,6 +1,6 @@
 description: The method is not allowed at the path.
 content:
-  application/json:
+  application/problem+json:
     schema:
       $ref: "../schemas/exception.yaml"
   text/html:

--- a/core/openapi/responses/NotFound.yaml
+++ b/core/openapi/responses/NotFound.yaml
@@ -1,6 +1,6 @@
 description: The requested URI was not found.
 content:
-  application/json:
+  application/problem+json:
     schema:
       $ref: "../schemas/exception.yaml"
   text/html:

--- a/core/openapi/responses/NotSupported.yaml
+++ b/core/openapi/responses/NotSupported.yaml
@@ -1,6 +1,6 @@
 description: None of the requested media types is supported at the path.
 content:
-  application/json:
+  application/problem+json:
     schema:
       $ref: "../schemas/exception.yaml"
   text/html:

--- a/core/openapi/responses/ServerError.yaml
+++ b/core/openapi/responses/ServerError.yaml
@@ -1,6 +1,6 @@
 description: A server error occurred.
 content:
-  application/json:
+  application/problem+json:
     schema:
       $ref: "../schemas/exception.yaml"
   text/html:


### PR DESCRIPTION
As described [here](https://github.com/opengeospatial/ogcapi-common/issues/318), we should use "application/problem+json" as Content-Type for exception.