### PR TITLE
Proposal OGC API - Processes - Part 2 updates

### DIFF
--- a/extensions/deploy_replace_undeploy/standard/openapi/responses/DeployProcess.yaml
+++ b/extensions/deploy_replace_undeploy/standard/openapi/responses/DeployProcess.yaml
@@ -1,0 +1,13 @@
+description: the process is deployed
+headers:
+  Location:
+    schema:
+      type: string
+    description: URL to fetch the processDescription of the deployed process
+content:
+  application/json:
+    schema:
+      content:
+        application/json:
+      schema:
+        $ref: "../schemas/staticIndicator.yaml"

--- a/extensions/deploy_replace_undeploy/standard/openapi/responses/DuplicateProcess.yaml
+++ b/extensions/deploy_replace_undeploy/standard/openapi/responses/DuplicateProcess.yaml
@@ -1,8 +1,8 @@
 description: the processes being added is already deployed (i.e. duplicate)
 content:
-  application/json:
+  application/problem+json:
     schema:
-      $ref: "https://raw.githubusercontent.com/opengeospatial/wps-rest-binding/master/core/openapi/schemas/exception.yaml"
+      $ref: "../../../../../core/openapi/schemas/exception.yaml"
   text/html:
     schema:
       type: string

--- a/extensions/deploy_replace_undeploy/standard/openapi/schemas/staticIndicator.yaml
+++ b/extensions/deploy_replace_undeploy/standard/openapi/schemas/staticIndicator.yaml
@@ -1,0 +1,7 @@
+allOf:
+  - $ref: "https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/processSummary.yaml"
+  - type: object
+    properties:
+      mutable:
+        type: boolean
+        default: true

--- a/extensions/deploy_replace_undeploy/standard/openapi/schemas/swagger/ogcapppkg.yaml
+++ b/extensions/deploy_replace_undeploy/standard/openapi/schemas/swagger/ogcapppkg.yaml
@@ -3,7 +3,7 @@ required:
   - executionUnit
 properties:
   processDescription:
-    $ref: ../../../../../core/openapi/schemas/process.yaml
+    $ref: ../../../../../../core/openapi/schemas/swagger/process.yaml
   executionUnit:
     description: Resource containing an executable or runtime information for executing the process.
     type: array


### PR DESCRIPTION
When we were testing the current OGC API - Processes - Part 2: Deploy, Replace, Undeploy schemas we faced various issues.

Some `$ref` were defined using the previous name of the GitHub repo (wps-rest-binding). 
The [ogcapppkg.yaml](https://github.com/opengeospatial/ogcapi-processes/compare/master...GeoLabs:ogcapi-processes:proposal-dru-updates?expand=1#diff-1da5d8e84254d7c4b793624365c113ebe7e2eb8bc55531a289fe8382a4a965b2) schema was not usable without modification.
The added [staticIndicator.yaml](https://github.com/opengeospatial/ogcapi-processes/compare/master...GeoLabs:ogcapi-processes:proposal-dru-updates?expand=1#diff-86aaa8f65d8695c32bcfb6d17329c5eca80f21a29c3ccbbd8123d8e030d2ad65) schema extends the [processSummary.yaml](https://github.com/opengeospatial/ogcapi-processes/blob/master/core/openapi/schemas/processSummary.yaml) one as expressed in [immutable processes section](https://github.com/opengeospatial/ogcapi-processes/blob/master/extensions/deploy_replace_undeploy/standard/sections/clause_6_deploy_replace_undeploy.adoc#immutable-processes).

Also, a specific `swagger` folder has been added for being able to use the schema from swagger-ui as illustrated [here](http://tb18.geolabs.fr:8080/swagger-ui/oapip/).

