### PR TITLE
Fix broken wording.

### DIFF
--- a/core/requirements/oas30/REQ_oas-definition-1.adoc
+++ b/core/requirements/oas30/REQ_oas-definition-1.adoc
@@ -4,7 +4,7 @@
 [%metadata]
 label:: /req/oas30/oas-definition-1
 part:: The content of the response of the HTTP GET operation at the landing page
-SHALL include the following lings to the API definition:
+SHALL include the following links to the API definition:
 
 * relation type `service-desc` and content type `application/vnd.oai.openapi+json;version=3.0
 * replation type `service-doc` and content type `text/html`

--- a/core/requirements/oas30/REQ_oas-definition-1.adoc
+++ b/core/requirements/oas30/REQ_oas-definition-1.adoc
@@ -3,5 +3,9 @@
 ====
 [%metadata]
 label:: /req/oas30/oas-definition-1
-part:: An OpenAPI definition in JSON using the media type `application/vnd.oai.openapi+json;version=3.0` and a HTML version of the API definition using the media type `text/html` SHALL be available.
+part:: The content of the response of the HTTP GET operation at the landing page
+SHALL include the following lings to the API definition:
+
+* relation type `service-desc` and content type `application/vnd.oai.openapi+json;version=3.0
+* replation type `service-doc` and content type `text/html`
 ====

--- a/core/requirements/oas30/REQ_oas-definition-1.adoc
+++ b/core/requirements/oas30/REQ_oas-definition-1.adoc
@@ -7,5 +7,5 @@ part:: The content of the response of the HTTP GET operation at the landing page
 SHALL include the following links to the API definition:
 
 * relation type `service-desc` and content type `application/vnd.oai.openapi+json;version=3.0
-* replation type `service-doc` and content type `text/html`
+* relation type `service-doc` and content type `text/html`
 ====


### PR DESCRIPTION
Fix broken wording for OAS requirement.  The current wording does not make it quite explicit that `rel=service-desc` should be used for the JSON version of the API document and that `rel=service-doc` should be used for the HTML version of the API document.