### PR TITLE
Remove references to addtionalParameters.

### DIFF
--- a/openapi/ogcapi-processes.bundled.json
+++ b/openapi/ogcapi-processes.bundled.json
@@ -4787,41 +4787,6 @@
           }
         }
       },
-      "additionalParameter": {
-        "type": "object",
-        "required": [
-          "name",
-          "value"
-        ],
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "value": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "array",
-                  "items": {}
-                },
-                {
-                  "type": "object"
-                }
-              ]
-            }
-          }
-        }
-      },
       "bbox-processes": {
         "type": "object",
         "required": [
@@ -4883,24 +4848,6 @@
             "items": {
               "$ref": "#/components/schemas/metadata"
             }
-          },
-          "additionalParameters": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/metadata"
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "parameters": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/additionalParameter"
-                    }
-                  }
-                }
-              }
-            ]
           }
         }
       },

--- a/openapi/ogcapi-processes.yaml
+++ b/openapi/ogcapi-processes.yaml
@@ -109,9 +109,6 @@ components:
          $ref: 'schemas/processes-core/processList.yaml'
       jobList:
          $ref: 'schemas/processes-core/jobList.yaml'
-
-      additionalParameter:
-         $ref: 'schemas/processes-core/additionalParameter.yaml'
       bbox-processes:
          $ref: 'schemas/processes-core/bbox.yaml'
       descriptionType:

--- a/openapi/schemas/processes-core/descriptionType.yaml
+++ b/openapi/schemas/processes-core/descriptionType.yaml
@@ -12,12 +12,3 @@ properties:
     type: array
     items:
       $ref: "metadata.yaml"
-  additionalParameters:
-    allOf:
-      - $ref: "metadata.yaml"
-      - type: object
-        properties:
-          parameters:
-            type: array
-            items:
-              $ref: "additionalParameter.yaml"


### PR DESCRIPTION
The `additionalParameters` stuff was added to OWS common ages ago to allow extensibility in XML without the need to rewrite the XML schemas each time.
For OAProc, which mainly uses JSON, there is no need for  this since the `additionalProperties` parameter (being `true` by default) allows additional keys to be added as required thus making the entire `additionalParameters` structure unnecessary.

This PR removes all references to `additionalParameters`.

Closes #351