### PR TITLE
fix invalid reference adoc OGC AppPkg schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+.vscode
 *.pdf
 core/standard/er.adoc
 core/standard/compiled/standard/er.pdf

--- a/extensions/deploy_replace_undeploy/standard/sections/clause_7_apppkg.adoc
+++ b/extensions/deploy_replace_undeploy/standard/sections/clause_7_apppkg.adoc
@@ -30,7 +30,7 @@ include::../requirements/ogcapppkg/REQ_schema.adoc[]
 .link:http://schemas.opengis.net/ogcapi/processes/part2/1.0/openapi/schemas/ogcapppkg.yaml[Schema for the OGC Application Package]
 [source,yaml]
 ----
-include::../../../openapi/schemas/processes-dru/ogcapppkg.yaml[]
+include::../../../../openapi/schemas/processes-dru/ogcapppkg.yaml[]
 ----
 
 ==== processDescription property


### PR DESCRIPTION
The `ogcapppkg` schema reference seemed to be missing one `../` to find the correct location. 