### PR TITLE
Value passing in an execute request.

### DIFF
--- a/core/requirements/core/REQ_process-execute-inputs.adoc
+++ b/core/requirements/core/REQ_process-execute-inputs.adoc
@@ -5,12 +5,22 @@
 identifier:: /req/core/process-execute-inputs
 [.component,class=part]
 --
-The server SHALL support process input values specified in-line in an execute request (i.e. by value).
+How process input values can be specified in an execute request (by-value, by-reference or both) SHALL be controlled by the https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/openapi/schemas/processes-core/inputDescription.yaml[`valuePassing`] parameter that may be specified per input in the <<sc_process_description,process description>>.
+--
+
+[.component,class=part]
+--
+The default value of the https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/openapi/schemas/processes-core/inputDescription.yaml[`valuePassing`] parameter shall be `["byValue","byReference"]`.
+--
+
+[.component,class=part]
+--
+If an input value can be passed by value (https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/openapi/schemas/processes-core/inputDescription.yaml[`"byValue"`]), process input values SHALL be specified in-line in an execute request.
 --
 
 [[input_by_reference]]
 [.component,class=part]
 --
-The server SHALL support process input values specified by reference (i.e. using a https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/openapi/schemas/common-core/link.yaml[link]).
+If an input value can be passed by reference (https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/openapi/schemas/processes-core/inputDescription.yaml[`"byReference"`]), then input values shall be referenced in an execute request using a https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/openapi/schemas/common-core/link.yaml[link].
 --
 ====

--- a/openapi/schemas/processes-core/inputDescription.yaml
+++ b/openapi/schemas/processes-core/inputDescription.yaml
@@ -6,8 +6,6 @@ allOf:
     properties:
       valuePassing:
         type: array
-        minItems: 1
-        maxItems: 2
         items:
            type: string
            enum:

--- a/openapi/schemas/processes-core/inputDescription.yaml
+++ b/openapi/schemas/processes-core/inputDescription.yaml
@@ -4,6 +4,16 @@ allOf:
     required:
       - schema
     properties:
+      valuePassing:
+        type: array
+        minItems: 1
+        maxItems: 2
+        items:
+           type: string
+           enum:
+             - "byValue"
+             - "byReference"
+        default: ["byValue","byReference"]
       minOccurs:
         type: integer
         default: 1


### PR DESCRIPTION
Allow value passing to be specified per input rather than requiring thes erver to support both by-value and by-refernce in all cases.  The default value for the `valuePassing` parameter is `["byValue","byReference"]` to maintain backward compatability.

Closes #369