### PR TITLE
Fix issue #282

### DIFF
--- a/extensions/deploy_replace_undeploy/standard/recommendations/deploy-replace-undeploy/package/REC_response-cwl.adoc
+++ b/extensions/deploy_replace_undeploy/standard/recommendations/deploy-replace-undeploy/package/REC_response-cwl.adoc
@@ -1,0 +1,9 @@
+[[rec_deploy-replace-undeploy_package_response-cwl]]
+[recommendation]
+====
+[%metadata]
+label:: /rec/deploy-replace-undeploy/package/response-cwl
+
+part:: If a process deployed as a <<rc_cwl,CWL>>, implementations SHOULD consider supporting the <<rc_cwl,CWL>> encoding.
+
+====

--- a/extensions/deploy_replace_undeploy/standard/recommendations/deploy-replace-undeploy/package/REC_response-ogcapppkg.adoc
+++ b/extensions/deploy_replace_undeploy/standard/recommendations/deploy-replace-undeploy/package/REC_response-ogcapppkg.adoc
@@ -1,0 +1,8 @@
+[[rec_deploy-replace-undeploy_package_response-ogcapppkg]]
+[recommendation]
+====
+[%metadata]
+label:: /rec/deploy-replace-undeploy/package/response-ogcapppkg
+
+part:: If a process was deployed as an <<rc_ogcapppkg,OGC Application Package>>, implementations SHOULD consider supporting the <<rc_ogcapppkg,OGC Application Package>> encoding.
+====

--- a/extensions/deploy_replace_undeploy/standard/requirements/cwl/package/REQ_response-body.adoc
+++ b/extensions/deploy_replace_undeploy/standard/requirements/cwl/package/REQ_response-body.adoc
@@ -1,0 +1,10 @@
+[[req_cwl_package_response-body]]
+[requirement]
+====
+[%metadata]
+label:: /req/cwl/package/response-body
+part:: A response with HTTP status code `200` SHALL include a body that contains:
+ * the <<rc_cwl,CWL>> to use to deploy the process, in case the Content-Type used to deploy the process was `application/cwl`. 
+ * the <<rc_ogcapppkg,OGC Application Package>> to use to deploy the process, in case the Content-Type used to deploy the process was `application/ogcapppkg+json`.
+ 
+====

--- a/extensions/deploy_replace_undeploy/standard/requirements/deploy-replace-undeploy/package/REQ_get-op.adoc
+++ b/extensions/deploy_replace_undeploy/standard/requirements/deploy-replace-undeploy/package/REQ_get-op.adoc
@@ -1,0 +1,9 @@
+[[req_deploy-replace-undeploy_package_get-op]]
+[requirement]
+====
+[%metadata]
+label:: /req/deploy-replace-undeploy/package/get-op
+part:: For every dynamically added process (path: /processes/{processId}), the server SHALL support the HTTP GET operation at the path `/processes/{processId}/package`.
+part:: The parameter `processId` is each `id` property in the process collection response (JSONPath: `$.processes[*].id`).
+
+====

--- a/extensions/deploy_replace_undeploy/standard/requirements/deploy-replace-undeploy/package/REQ_get-op.adoc
+++ b/extensions/deploy_replace_undeploy/standard/requirements/deploy-replace-undeploy/package/REQ_get-op.adoc
@@ -3,7 +3,7 @@
 ====
 [%metadata]
 label:: /req/deploy-replace-undeploy/package/get-op
-part:: For every dynamically added process (path: /processes/{processId}), the server SHALL support the HTTP GET operation at the path `/processes/{processId}/package`.
+part:: For every dynamically added process (using method: POST on path: /processes/{processId}), the server SHALL support the HTTP GET operation at the path `/processes/{processId}/package`.
 part:: The parameter `processId` is each `id` property in the process collection response (JSONPath: `$.processes[*].id`).
 
 ====

--- a/extensions/deploy_replace_undeploy/standard/requirements/deploy-replace-undeploy/package/REQ_response-body.adoc
+++ b/extensions/deploy_replace_undeploy/standard/requirements/deploy-replace-undeploy/package/REQ_response-body.adoc
@@ -1,0 +1,7 @@
+[[req_deploy-replace-undeploy_package_response-body]]
+[requirement]
+====
+[%metadata]
+label:: /req/deploy-replace-undeploy/package/response-body
+part:: A response with HTTP status code `200` SHALL include a body that contains the request body used to deploy or replace the process.
+====

--- a/extensions/deploy_replace_undeploy/standard/requirements/deploy-replace-undeploy/package/REQ_response-success.adoc
+++ b/extensions/deploy_replace_undeploy/standard/requirements/deploy-replace-undeploy/package/REQ_response-success.adoc
@@ -1,0 +1,7 @@
+[[req_deploy-replace-undeploy_package_response-success]]
+[requirement]
+====
+[%metadata]
+label:: /req/deploy-replace-undeploy/package/response-success
+part:: A successful access to the resource SHALL be reported as a response with a HTTP status code `200`.
+====

--- a/extensions/deploy_replace_undeploy/standard/requirements/ogcapppkg/package/REQ_response-body.adoc
+++ b/extensions/deploy_replace_undeploy/standard/requirements/ogcapppkg/package/REQ_response-body.adoc
@@ -1,0 +1,7 @@
+[[req_ogcapppkg_package_response-body]]
+[requirement]
+====
+[%metadata]
+label:: /req/ogcapppkg/package/response-body
+part:: A response with HTTP status code `200` SHALL include a body that contains the <<rc_ogcapppkg,OGC Application Package>> to use to deploy the process.
+====

--- a/extensions/deploy_replace_undeploy/standard/sections/annex_history.adoc
+++ b/extensions/deploy_replace_undeploy/standard/sections/annex_history.adoc
@@ -17,4 +17,5 @@
 |2023-12-06 |None |Gérald Fenoy |all |Abstract Test Suite Updates
 |2023-12-07 |None |Gérald Fenoy |all |Fix mixed status code and value in security consideration
 |2023-12-08 |None |Gérald Fenoy |all |Add requirements for managing docker image as execution unit
+|2024-04-26 |None |Gérald Fenoy |all |Add section for retrieving formal description of a mutable process
 |===

--- a/extensions/deploy_replace_undeploy/standard/sections/clause_6_deploy_replace_undeploy.adoc
+++ b/extensions/deploy_replace_undeploy/standard/sections/clause_6_deploy_replace_undeploy.adoc
@@ -257,3 +257,28 @@ See <<deploy-replace-undeploy-http_status_codes,HTTP status codes>> for general 
 If the process with the specified identifier does not exist on the server, see requirement /req/core/process-exception/no-such-process from <<OAProc-1>>.
 
 If the process exist but is immutable then <<req_deploy-replace-undeploy_deploy_response-immutable,/req/deploy-replace-undeploy/deploy/response-immutable>> applies.
+
+[[deploy-replace-undeploy-package]]
+=== Retrieving the formal description
+
+For every process deployed to the server, it is possible to retrieve its formal description. It corresponds to the request's body used to deploy or replace the process.
+
+==== Operation
+
+include::../requirements/deploy-replace-undeploy/package/REQ_get-op.adoc[]
+
+==== Response
+
+===== Overview
+
+include::../requirements/deploy-replace-undeploy/package/REQ_response-success.adoc[]
+
+include::../requirements/deploy-replace-undeploy/package/REQ_response-body.adoc[]
+
+==== Exceptions
+
+See <<deploy-replace-undeploy-http_status_codes,HTTP status codes>> for general guidance.
+
+If the process with the specified identifier does not exist on the server, see requirement /req/core/process-exception/no-such-process from <<OAProc-1>>.
+
+If the process exist but is immutable then <<req_deploy-replace-undeploy_deploy_response-immutable,/req/deploy-replace-undeploy/deploy/response-immutable>> applies.

--- a/extensions/deploy_replace_undeploy/standard/sections/clause_6_deploy_replace_undeploy.adoc
+++ b/extensions/deploy_replace_undeploy/standard/sections/clause_6_deploy_replace_undeploy.adoc
@@ -261,7 +261,7 @@ If the process exist but is immutable then <<req_deploy-replace-undeploy_deploy_
 [[deploy-replace-undeploy-package]]
 === Retrieving the formal description
 
-For every process deployed to the server, it is possible to retrieve its formal description. It corresponds to the request's body used to deploy or replace the process.
+For every mutable process, it is possible to retrieve its formal description. It corresponds to the request's body used to deploy or replace the process.
 
 ==== Operation
 

--- a/extensions/deploy_replace_undeploy/standard/sections/clause_7_apppkg.adoc
+++ b/extensions/deploy_replace_undeploy/standard/sections/clause_7_apppkg.adoc
@@ -58,3 +58,9 @@ include::../requirements/ogcapppkg/deploy/REQ_body.adoc[]
 ==== OGC Application Package body
 
 include::../requirements/ogcapppkg/replace/REQ_body.adoc[]
+
+=== Formal description
+
+==== OGC Application Package content
+
+include::../requirements/ogcapppkg/package/REQ_response-body.adoc[]

--- a/extensions/deploy_replace_undeploy/standard/sections/clause_9_cwl.adoc
+++ b/extensions/deploy_replace_undeploy/standard/sections/clause_9_cwl.adoc
@@ -63,3 +63,8 @@ include::../requirements/cwl/deploy/REQ_exception-workflow-not-found.adoc[]
 
 include::../requirements/cwl/replace/REQ_body.adoc[]
 
+=== Formal description
+
+==== CWL content
+
+include::../requirements/cwl/package/REQ_response-body.adoc[]

--- a/openapi/paths/processes-dru/pPackage.yaml
+++ b/openapi/paths/processes-dru/pPackage.yaml
@@ -14,12 +14,12 @@ get:
               $ref: "../../schemas/processes-dru/ogcapppkg.yaml"
          application/cwl:
             schema:
-              $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/1.2.1_proposed/json-schema/cwl.yaml"
+              $ref: "https://raw.githubusercontent.com/common-workflow-lab/cwl-ts-auto/main/json_schemas/cwl_schema.yaml"
          application/cwl+json:
             schema:
-              $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/1.2.1_proposed/json-schema/cwl.yaml"
+              $ref: "https://raw.githubusercontent.com/common-workflow-lab/cwl-ts-auto/main/json_schemas/cwl_schema.yaml"
          application/cwl+yaml:
             schema:
-              $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/1.2.1_proposed/json-schema/cwl.yaml"
+              $ref: "https://raw.githubusercontent.com/common-workflow-lab/cwl-ts-auto/main/json_schemas/cwl_schema.yaml"
      404:
         $ref: "../../responses/common-core/rNotFound.yaml"

--- a/openapi/paths/processes-dru/pPackage.yaml
+++ b/openapi/paths/processes-dru/pPackage.yaml
@@ -1,0 +1,25 @@
+get:
+   summary: retrieve the formal description used to deploy a process
+   description: |
+      Access the formal description that can be used to deploy a process on an OGC API - Processes Server Instance.
+   operationId: getPackage
+   tags:
+     - Package
+   responses:
+     200:
+       description: The formal used to deploy a process
+       content:
+         application/ogcapppkg+json:
+            schema:
+              $ref: "../../schemas/processes-dru/ogcapppkg.yaml"
+         application/cwl:
+            schema:
+              $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/1.2.1_proposed/json-schema/cwl.yaml"
+         application/cwl+json:
+            schema:
+              $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/1.2.1_proposed/json-schema/cwl.yaml"
+         application/cwl+yaml:
+            schema:
+              $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/1.2.1_proposed/json-schema/cwl.yaml"
+     404:
+        $ref: "../../responses/common-core/rNotFound.yaml"


### PR DESCRIPTION
As discussed on April 15, 2024, during the SWG meeting, we propose the following additions.

Add /processes/{processId}/package path for accessing the formal description used to deploy a process.

Add specific recommendations and requirements for the OGC Application Package and CWL conformance classes.