### PR TITLE
Typo in processes-types.yaml (closes #447)

### DIFF
--- a/openapi/schemas/processes-job-management/processes-type.yaml
+++ b/openapi/schemas/processes-job-management/processes-type.yaml
@@ -1,5 +1,6 @@
 type: string
 nullable: false
-enum:
+example:
   - process
   - openeo
+  - wps


### PR DESCRIPTION
The `enum` defined in the `processes-type.yaml` is now replaced by `example`. With it, the `type` attribute is no longer restricted to predefined values, easing potential integration in other Standards (ref. #447).