### PR TITLE
adjust description of `process` in execute-workflows.yaml

### DIFF
--- a/openapi/schemas/processes-workflows/execute-workflows.yaml
+++ b/openapi/schemas/processes-workflows/execute-workflows.yaml
@@ -4,7 +4,7 @@ allOf:
         process:
           type: string
           format: uri-reference
-          description: URI to the process execution end point (i.e., `.../processes/{processId}/execution`)
+          description: URI to the process description end point (i.e., `.../processes/{processId}`)
         inputs:
           additionalProperties:
             $ref: "input-workflows.yaml"


### PR DESCRIPTION
The URI description is misleading when looking at examples (eg: https://docs.ogc.org/DRAFTS/21-009.html#_192ed695-ac52-4c60-97a1-c2df43bd7ac9). 

It points at the process *description* endpoint, not the execution.
