### PR TITLE
Remote requirements/recommendations about "profileEntityType".

### DIFF
--- a/core/recommendations/core/PER_job-success.adoc
+++ b/core/recommendations/core/PER_job-success.adoc
@@ -1,9 +1,0 @@
-[[per-job-success]]
-[permission]
-====
-[%metadata]
-identifier:: /per/core/job-success
-label:: /per/core/job-success
-
-Servers MAY set the value of the `profileEntityType` to indicate the requested profile represenation of the response.  This value may differ from the value of the `processingEntityType`.
-====

--- a/core/sections/clause_18_profile.adoc
+++ b/core/sections/clause_18_profile.adoc
@@ -30,3 +30,6 @@ include::../recommendations/query-param-profile/REC_negotiation.adoc[]
 include::../requirements/query-param-profile/REQ_response.adoc[]
 
 include::../recommendations/query-param-profile/REC_link-header.adoc[]
+
+NOTE: A set of profile URIs for content defined in this Standard can be found in the <<profile-uris,Profile identifiers>> table.
+

--- a/core/sections/clause_7_core.adoc
+++ b/core/sections/clause_7_core.adoc
@@ -281,6 +281,8 @@ More specifically:
 
 Note that the `Link` header with `profile` parameter MUST be returned for any of the content negotiation by profile strategies if an applicable URI could be resolved.  Other headers (`Preference-Applied` and `Content-Type`) containing a `profile` parameter are relevant in the response only when they were explicitly requested by their corresponding request headers (`Prefer` and `Accept`) containing the same `profile` identifier, ￼or when the `profile` does not correspond to an URI than can be provided as `Link: href="<URI>"` value (e.g.: `profile=cloud-optimized` for a GeoTiff).
 
+NOTE: A set of profile URIs for content defined in this Standard can be found in the <<profile-uris,Profile identifiers>> table.
+
 [[sc_limit_parameter]]
 === Limit parameter
 

--- a/core/sections/clause_7_core.adoc
+++ b/core/sections/clause_7_core.adoc
@@ -1247,7 +1247,7 @@ include::../requirements/core/REQ_job-op.adoc[]
 
 include::../requirements/core/REQ_job-success.adoc[]
 
-include::../recommendations/core/PER_job-success.adoc[]
+NOTE: In the case where a server supports multiple processing APIs (e.g. OGC API - Processes, OpenEO, etc.) the <<profile-parameter,profile mechanism>> may be use by non-OGC clients to interact with the `/jobs` endpoint and request status information in a schema that they recognize.
 
 [[schema-statusInfo]]
 .Schema for status info

--- a/core/sections/clause_7_core.adoc
+++ b/core/sections/clause_7_core.adoc
@@ -1249,7 +1249,7 @@ include::../requirements/core/REQ_job-op.adoc[]
 
 include::../requirements/core/REQ_job-success.adoc[]
 
-NOTE: In the case where a server supports multiple processing APIs (e.g. OGC API - Processes, OpenEO, etc.) the <<profile-parameter,profile mechanism>> may be use by non-OGC clients to interact with the `/jobs` endpoint and request status information in a schema that they recognize.
+NOTE: In the case where a server supports multiple processing APIs (e.g. OGC API - Processes, OpenEO, etc.) the <<profile-parameter,profile mechanism>> may be use by non-OGC clients to interact with the `/jobs` endpoint and request status information in a schema that they recognize.  Profile URIs for content defined in this Standard can be found in the <<profile-uris,Profile identifiers>> table.
 
 [[schema-statusInfo]]
 .Schema for status info


### PR DESCRIPTION
Removed the relevant requirements/recommendations and added a small informative text block indicating that the profile mechanism can be used to negotiate for other representations.

Closes #517 