### PR TITLE
fix typos in KVP schemas

### DIFF
--- a/core/requirements/core/REQ_job-results-param-outputs.adoc
+++ b/core/requirements/core/REQ_job-results-param-outputs.adoc
@@ -7,7 +7,7 @@ label:: /req/core/job-results-param-outputs
 
 [.component,class=part]
 --
-The operation at the `/jobs/{jobID}/results` endpoint SHALL support a parameter `outputs` with the following characteristics (using an OpenAPI Specification fragment):
+The operation at the `/jobs/{jobID}/results` endpoint SHALL support a query parameter `outputs` with the following characteristics (using an OpenAPI Specification fragment):
 
 [source,yaml]
 ----
@@ -17,7 +17,7 @@ required: false
 schema:
   type: array
   items:
-    type:string
+    type: string
 style: form
 explode: false
 ----

--- a/core/requirements/kvp-execute/REQ_output.adoc
+++ b/core/requirements/kvp-execute/REQ_output.adoc
@@ -24,7 +24,7 @@ schema:
   required:
     - include
   properties:
-    include
+    include:
       type: boolean
     mediaType:
       type: string


### PR DESCRIPTION

- fix typos in KVP schemas
- Add the "query" as suggested in https://github.com/opengeospatial/ogcapi-processes/issues/538