### PR TITLE
update the CWL schema references to official URI

### DIFF
--- a/openapi/paths/processes-dru/pDeploy.yaml
+++ b/openapi/paths/processes-dru/pDeploy.yaml
@@ -19,13 +19,13 @@ post:
            $ref: "../../schemas/processes-dru/ogcapppkg.yaml"
        application/cwl:
          schema:
-           $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
+           $ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
        application/cwl+json:
          schema:
-           $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
+           $ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
        application/cwl+yaml:
          schema:
-           $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
+           $ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
    responses:
      201:
        $ref: "../../schemas/processes-core/processSummary.yaml"

--- a/openapi/paths/processes-dru/pProcessDescriptionReplaceUndeploy.yaml
+++ b/openapi/paths/processes-dru/pProcessDescriptionReplaceUndeploy.yaml
@@ -38,13 +38,13 @@ put:
            $ref: "../../schemas/processes-dru/ogcapppkg.yaml"
        application/cwl:
          schema:
-           $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
+           $ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
        application/cwl+json:
          schema:
-           $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
+           $ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
        application/cwl+yaml:
          schema:
-           $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
+           $ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
    responses:
      204:
        $ref: "../../responses/processes-core/rEmpty.yaml"

--- a/openapi/paths/processes-dru/pProcessListDeploy.yaml
+++ b/openapi/paths/processes-dru/pProcessListDeploy.yaml
@@ -31,13 +31,13 @@ post:
            $ref: "../../schemas/processes-dru/ogcapppkg.yaml"
        application/cwl:
          schema:
-           $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
+           $ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
        application/cwl+json:
          schema:
-           $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
+           $ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
        application/cwl+yaml:
          schema:
-           $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
+           $ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
    responses:
      201:
        $ref: "../../schemas/processes-core/processSummary.yaml"

--- a/openapi/paths/processes-dru/pReplace.yaml
+++ b/openapi/paths/processes-dru/pReplace.yaml
@@ -19,13 +19,13 @@ put:
            $ref: "../../schemas/processes-dru/ogcapppkg.yaml"
        application/cwl:
          schema:
-           $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
+           $ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
        application/cwl+json:
          schema:
-           $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
+           $ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
        application/cwl+yaml:
          schema:
-           $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
+           $ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
    responses:
      204:
        $ref: "../../responses/processes-core/rEmpty.yaml"


### PR DESCRIPTION
The schema have been updated to employ the official endpoint release of CWL v1.2: 

- https://www.commonwl.org/v1.2/cwl-json-schema.yaml

- Relates to https://github.com/common-workflow-language/cwl-v1.2/pull/295