### PR TITLE
OpenAPI fixes for #414 #560 #567

### DIFF
--- a/openapi/ogcapi-processes.bundled.json
+++ b/openapi/ogcapi-processes.bundled.json
@@ -630,9 +630,6 @@
           },
           {
             "$ref": "#/components/parameters/N"
-          },
-          {
-            "$ref": "#/paths/~1jobs~1%7BjobID%7D~1results/get/parameters/1"
           }
         ],
         "responses": {

--- a/openapi/ogcapi-processes.bundled.json
+++ b/openapi/ogcapi-processes.bundled.json
@@ -5989,7 +5989,7 @@
               "process": {
                 "type": "string",
                 "format": "uri-reference",
-                "description": "URI to the process description end point (i.e., `.../processes/{processId}`)"
+                "description": "The URI to the description of the process that should be executed.\nFor the top-level process, when the execution request is POSTed to `{root}/processes/{processId}/execution`, this should be an absolute URI,\nand the server should ignore this `process` key since the URI of the request already identifies the process to execute, and a client\nis not required to resolve and replace the URI if passing a nested process block as part of a larger workflow executing a nested process.\nIf a relative URI reference is used, the Base URI is defined as the URI of the description\n(`{root}/processes/{processId}`) of the receiving process, with this receiving process object understood as the\nEncapsulating Entity as per [RFC 3986 Section 5.1.2](https://datatracker.ietf.org/doc/html/rfc3986#section-5.1.2).\nIn the case of a nested process on the same OGC API root as the receiving process, using a simple process ID as the relative URI reference\nwould resolve to a process available at `{root}/processes/{processID}`, where `{root}` represents the landing page of the receiving process.\nFor example, if a top-level process at https://example.com/processes/buffer receives a nested processs `{ \"process\": \"clip\" }`,\nthat clip process is resolved as https://example.com/processes/clip."
               },
               "inputs": {
                 "additionalProperties": {
@@ -6183,8 +6183,17 @@
             "properties": {
               "collection": {
                 "description": "The URI of the OGC API collection that should be accessed to provide\ninput values from the corresponding process input.  The server\noffering this collection is referred to as the \"value source server\".",
-                "type": "string",
-                "format": "uri-reference"
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "Collection identifier for a collection available at `{root}/collections/{collectionID}`, where `{root}` represents the landing page\nof the process using the collection as an input (for the top-level process, that is the landing page of the process execution endpoint\nto which the execution request is posted), or the landing page of the document being retrieved in the case of an output.\nIf the `collection` string includes a `/`, it must be interpreted as a URI reference rather than as a collection ID."
+                  },
+                  {
+                    "type": "string",
+                    "description": "The URI of an OGC API collection.\nIf a relative URI reference is used, the Base URI is defined as such:\n- For a Collection value received as input to a process, the Base URI is defined as the URI of the description\n  (`{root}/processes/{processId}`) of that process, with the receiving process object understood as the Encapsulating Entity as per\n  [RFC 3986 Section 5.1.2](https://datatracker.ietf.org/doc/html/rfc3986#section-5.1.2).\n- For a Collection Output value, the Base URI is defined from the Retrieval URI as as per\n  [RFC 3986 Section 5.1.3](https://datatracker.ietf.org/doc/html/rfc3986#section-5.1.3),\n  for example, `/jobs/{jobId}/results`, `/jobs/{jobId}/results/{outputID}` or `/jobs/{jobId}/results/{outputID}/{N}` depending on the\n  resource being retrieved.\nIf a collection string does not contain any `/`, it must not be interpreted as a URI reference, and must instead be resolved as a\ncollection identifier. For example, `countries` would resolve to `{root}/collections/countries` rather than `{root}/processes/countries`.",
+                    "format": "uri-reference"
+                  }
+                ]
               },
               "bbox": {
                 "description": "Only resources that have a geometry that intersects the bounding box\nare selected.  The bounding box is provided as four or six numbers,\ndepending on whether the coordinate reference system includes a\nvertical axis (height or depth):\n\n* Lower left corner, coordinate axis 1\n* Lower left corner, coordinate axis 2\n* Minimum value, coordinate axis 3 (optional)\n* Upper right corner, coordinate axis 1\n* Upper right corner, coordinate axis 2\n* Maximum value, coordinate axis 3 (optional)\n\nIf the value consists of four numbers, the coordinate reference\nsystem is WGS84 longitude/latitude\n  (http://www.opengis.net/def/crs/OGC/1.3/CRS84)\nunless a different coordinate reference system is specified in the\nparameter `bboxCrs`.\n\nIf the value consists of six numbers, the coordinate reference system\nis WGS84 (http://www.opengis.net/def/crs/OGC/0/CRS84h) longitude/\nlatitude/ ellipsoidal height unless a different coordinate reference\nsystem is specified in the parameter `bboxCrs`.\n\nFor WGS84 longitude/latitude the values are in most cases the sequence\nof minimum longitude, minimum latitude, maximum longitude and maximum\nlatitude.  However, in cases where the box spans the antimeridian the\nfirst value (west-most box edge) is larger than the third value\n(east-most box edge).\n\nIf the vertical axis is included, the third and the sixth number are\nthe bottom and the top of the 3-dimensional bounding box.\n\nIf a resource has multiple spatial geometry properties, it is the\ndecision of the server whether only a single spatial geometry property\nis used to determine the extent or all relevant geometries.",

--- a/openapi/ogcapi-processes.bundled.json
+++ b/openapi/ogcapi-processes.bundled.json
@@ -580,6 +580,73 @@
           }
         }
       }
+    },
+    "/jobs/{jobID}/results/{outputID}": {
+      "get": {
+        "summary": "retrieve a specific resulting output of a job",
+        "description": "Retrieve a specific resulting output for a job.\n\nFor more information, see [Section 7.14](https://docs.ogc.org/is/18-062r3/18-062r3.html#sc_retrieve_job_results_one).\n",
+        "operationId": "getOutput",
+        "tags": [
+          "Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/jobID"
+          },
+          {
+            "$ref": "#/components/parameters/outputID"
+          },
+          {
+            "$ref": "#/paths/~1jobs~1%7BjobID%7D~1results/get/parameters/1"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Output"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/jobs/{jobID}/results/{outputID}/{N}": {
+      "get": {
+        "summary": "retrieve a single value from an output of a job allowing multiple values",
+        "description": "Retrieve a single value from an output of a job allowing multiple values (maxOccurs > 1)\n\nFor more information, see [Section 7.14](https://docs.ogc.org/is/18-062r3/18-062r3.html#sc_retrieve_job_results_one).\n",
+        "operationId": "getOutputValue",
+        "tags": [
+          "Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/jobID"
+          },
+          {
+            "$ref": "#/components/parameters/outputID"
+          },
+          {
+            "$ref": "#/components/parameters/N"
+          },
+          {
+            "$ref": "#/paths/~1jobs~1%7BjobID%7D~1results/get/parameters/1"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Output"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -7304,6 +7371,15 @@
           "type": "string"
         }
       },
+      "N": {
+        "name": "N",
+        "in": "path",
+        "description": "0-based index identifying a specific value of a multi-values output resulting from a job",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
       "jobID": {
         "name": "jobID",
         "in": "path",
@@ -7628,6 +7704,26 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/results"
+            }
+          }
+        }
+      },
+      "Output": {
+        "description": "An output resulting from a job",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/values"
+            }
+          }
+        }
+      },
+      "OutputValue": {
+        "description": "An individual value of an output allowing multiple values resulting from a job",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/inlineOrRefValue"
             }
           }
         }

--- a/openapi/ogcapi-processes.yaml
+++ b/openapi/ogcapi-processes.yaml
@@ -59,6 +59,11 @@ paths:
    /jobs/{jobID}/results:
       $ref: 'paths/processes-core/pJobResults.yaml'
 
+   /jobs/{jobID}/results/{outputID}:
+      $ref: 'paths/processes-core/pResultOutput.yaml'
+
+   /jobs/{jobID}/results/{outputID}/{N}:
+      $ref: 'paths/processes-core/pResultOutputValue.yaml'
 
 components:
    schemas:
@@ -439,9 +444,12 @@ components:
       # Processes - Core
       processID-path:
          $ref: 'parameters/processes-core/processID-path.yaml'
-      # Processes - Core (1.1?)
+      # Processes - Core (2.0)
       outputID:
          $ref: 'parameters/processes-core/outputID.yaml'
+      # Processes - Core (2.0)
+      N:
+         $ref: 'parameters/processes-core/N.yaml'
 
       # Processes - Core (Jobs)
       jobID:
@@ -503,6 +511,10 @@ components:
 
       Results:
          $ref: 'responses/processes-core/rResults.yaml'
+      Output:
+         $ref: 'responses/processes-core/rOutput.yaml'
+      OutputValue:
+         $ref: 'responses/processes-core/rOutputValue.yaml'
       Status:
          $ref: 'responses/processes-core/rStatus.yaml'
       JobList:

--- a/openapi/parameters/processes-core/N.yaml
+++ b/openapi/parameters/processes-core/N.yaml
@@ -1,0 +1,6 @@
+name: N
+in: path
+description: 0-based index identifying a specific value of a multi-values output resulting from a job
+required: true
+schema:
+  type: string

--- a/openapi/paths/processes-core/pResultOutput.yaml
+++ b/openapi/paths/processes-core/pResultOutput.yaml
@@ -1,0 +1,21 @@
+get:
+   summary: retrieve a specific resulting output of a job
+   description: |
+     Retrieve a specific resulting output for a job.
+
+     For more information, see [Section 7.14](https://docs.ogc.org/is/18-062r3/18-062r3.html#sc_retrieve_job_results_one).
+
+   operationId: getOutput
+   tags:
+     - Jobs
+   parameters:
+     - $ref: "../../parameters/processes-core/jobID.yaml"
+     - $ref: "../../parameters/processes-core/outputID.yaml"
+     - $ref: "../../parameters/processes-core/prefer-header-results.yaml"
+   responses:
+     200:
+       $ref: "../../responses/processes-core/rOutput.yaml"
+     404:
+       $ref: "../../responses/common-core/rNotFound.yaml"
+     500:
+       $ref: "../../responses/common-core/rServerError.yaml"

--- a/openapi/paths/processes-core/pResultOutputValue.yaml
+++ b/openapi/paths/processes-core/pResultOutputValue.yaml
@@ -1,0 +1,22 @@
+get:
+   summary: retrieve a single value from an output of a job allowing multiple values
+   description: |
+     Retrieve a single value from an output of a job allowing multiple values (maxOccurs > 1)
+
+     For more information, see [Section 7.14](https://docs.ogc.org/is/18-062r3/18-062r3.html#sc_retrieve_job_results_one).
+
+   operationId: getOutputValue
+   tags:
+     - Jobs
+   parameters:
+     - $ref: "../../parameters/processes-core/jobID.yaml"
+     - $ref: "../../parameters/processes-core/outputID.yaml"
+     - $ref: "../../parameters/processes-core/N.yaml"
+     - $ref: "../../parameters/processes-core/prefer-header-results.yaml"
+   responses:
+     200:
+       $ref: "../../responses/processes-core/rOutput.yaml"
+     404:
+       $ref: "../../responses/common-core/rNotFound.yaml"
+     500:
+       $ref: "../../responses/common-core/rServerError.yaml"

--- a/openapi/paths/processes-core/pResultOutputValue.yaml
+++ b/openapi/paths/processes-core/pResultOutputValue.yaml
@@ -12,7 +12,6 @@ get:
      - $ref: "../../parameters/processes-core/jobID.yaml"
      - $ref: "../../parameters/processes-core/outputID.yaml"
      - $ref: "../../parameters/processes-core/N.yaml"
-     - $ref: "../../parameters/processes-core/prefer-header-results.yaml"
    responses:
      200:
        $ref: "../../responses/processes-core/rOutput.yaml"

--- a/openapi/responses/processes-core/rOutput.yaml
+++ b/openapi/responses/processes-core/rOutput.yaml
@@ -1,0 +1,5 @@
+description: An output resulting from a job
+content:
+  application/json:
+    schema:
+      $ref: "../../schemas/processes-core/values.yaml"

--- a/openapi/responses/processes-core/rOutputValue.yaml
+++ b/openapi/responses/processes-core/rOutputValue.yaml
@@ -1,0 +1,5 @@
+description: An individual value of an output allowing multiple values resulting from a job
+content:
+  application/json:
+    schema:
+      $ref: "../../schemas/processes-core/inlineOrRefValue.yaml"

--- a/openapi/schemas/processes-core/collectionValue.yaml
+++ b/openapi/schemas/processes-core/collectionValue.yaml
@@ -9,8 +9,27 @@ allOf:
            The URI of the OGC API collection that should be accessed to provide
            input values from the corresponding process input.  The server
            offering this collection is referred to as the "value source server".
-        type: string
-        format: uri-reference
+        anyOf:
+           - type: string
+             description: |-
+               Collection identifier for a collection available at `{root}/collections/{collectionID}`, where `{root}` represents the landing page
+               of the process using the collection as an input (for the top-level process, that is the landing page of the process execution endpoint
+               to which the execution request is posted), or the landing page of the document being retrieved in the case of an output.
+               If the `collection` string includes a `/`, it must be interpreted as a URI reference rather than as a collection ID.
+           - type: string
+             description: |-
+                The URI of an OGC API collection.
+                If a relative URI reference is used, the Base URI is defined as such:
+                - For a Collection value received as input to a process, the Base URI is defined as the URI of the description
+                  (`{root}/processes/{processId}`) of that process, with the receiving process object understood as the Encapsulating Entity as per
+                  [RFC 3986 Section 5.1.2](https://datatracker.ietf.org/doc/html/rfc3986#section-5.1.2).
+                - For a Collection Output value, the Base URI is defined from the Retrieval URI as as per
+                  [RFC 3986 Section 5.1.3](https://datatracker.ietf.org/doc/html/rfc3986#section-5.1.3),
+                  for example, `/jobs/{jobId}/results`, `/jobs/{jobId}/results/{outputID}` or `/jobs/{jobId}/results/{outputID}/{N}` depending on the
+                  resource being retrieved.
+                If a collection string does not contain any `/`, it must not be interpreted as a URI reference, and must instead be resolved as a
+                collection identifier. For example, `countries` would resolve to `{root}/collections/countries` rather than `{root}/processes/countries`.
+             format: uri-reference
       bbox:
         description: |-
           Only resources that have a geometry that intersects the bounding box

--- a/openapi/schemas/processes-core/execute.yaml
+++ b/openapi/schemas/processes-core/execute.yaml
@@ -1,8 +1,9 @@
 type: object
 properties:
-  processID:
+  process:
     type: string
     format: uri
+    description: The URI to the description of the process that should be executed.
   inputs:
     additionalProperties:
       $ref: "values.yaml"

--- a/openapi/schemas/processes-workflows/execute-workflows.yaml
+++ b/openapi/schemas/processes-workflows/execute-workflows.yaml
@@ -4,7 +4,18 @@ allOf:
         process:
           type: string
           format: uri-reference
-          description: URI to the process description end point (i.e., `.../processes/{processId}`)
+          description: |-
+             The URI to the description of the process that should be executed.
+             For the top-level process, when the execution request is POSTed to `{root}/processes/{processId}/execution`, this should be an absolute URI,
+             and the server should ignore this `process` key since the URI of the request already identifies the process to execute, and a client
+             is not required to resolve and replace the URI if passing a nested process block as part of a larger workflow executing a nested process.
+             If a relative URI reference is used, the Base URI is defined as the URI of the description
+             (`{root}/processes/{processId}`) of the receiving process, with this receiving process object understood as the
+             Encapsulating Entity as per [RFC 3986 Section 5.1.2](https://datatracker.ietf.org/doc/html/rfc3986#section-5.1.2).
+             In the case of a nested process on the same OGC API root as the receiving process, using a simple process ID as the relative URI reference
+             would resolve to a process available at `{root}/processes/{processID}`, where `{root}` represents the landing page of the receiving process.
+             For example, if a top-level process at https://example.com/processes/buffer receives a nested processs `{ "process": "clip" }`,
+             that clip process is resolved as https://example.com/processes/clip.
         inputs:
           additionalProperties:
             $ref: "values-workflows.yaml"


### PR DESCRIPTION
- Adding missing paths `/jobs/{jobID}/results/{outputID}` and `/jobs/{jobID}/results/{outputID}/{N}`
- Change `processID` to `process` in Core to match workflows and the fact that this is a full URI
- Change "collection" from `uri-reference` to `uri` or `string` (`{collectionId}`) as discussed in https://github.com/opengeospatial/ogcapi-processes/issues/540#issuecomment-3774139649
- Changing `"process": ` in Workflows to allow `uri` (absolute URI to the process) or `string` (`{processId}`) instead of `uri-reference` (unchanged in Part 1, since process should probably always be a full URI in this case since it is at the top level)