### PR TITLE
add more Part4 Job PROV media types

### DIFF
--- a/extensions/job_management/standard/recommendations/provenance/prov/PER_content-negotiation.adoc
+++ b/extensions/job_management/standard/recommendations/provenance/prov/PER_content-negotiation.adoc
@@ -2,9 +2,67 @@
 [permission]
 ====
 [%metadata]
-label:: /per/provenance/prov-content-negotiation
-part:: Content negotiation MAY be supported to provide alternate representations of the response.
-part:: The server MAY support the following additional content type: `application/ld+json` for PROV-O as JSON-LD
-part:: The server MAY support the following additional content type: `application/xml` for PROV-XML 
-part:: The server MAY support the following additional content type: `text/provenance-notation; charset="UTF-8"` for PROV-N.
+identifier:: /per/provenance/prov-content-negotiation
+
+[.component,class=part]
+--
+Content negotiation MAY be supported to provide alternate representations of the response.
+--
+
+[.component,class=part]
+--
+The server MAY support the following content type: `application/json` _explicitly provided_
+in accordance to the default requirement (see <<req_provenance_prov_response,PROV Response>>)
+for link:https://www.w3.org/submissions/prov-json/[PROV-JSON] as
+a link:https://www.w3.org/TR/2013/NOTE-prov-overview-20130430/[PROV] representation
+in JSON using the link:https://www.w3.org/TR/2013/REC-prov-dm-20130430/[PROV-DM] data model.
+--
+
+[.component,class=part]
+--
+The server MAY support the following additional content type: `application/ld+json`
+for link:https://www.w3.org/submissions/prov-jsonld/[PROV-JSONLD] as
+a link:https://www.w3.org/TR/2013/NOTE-prov-overview-20130430/[PROV] representation
+in link:https://www.w3.org/TR/json-ld/[JSON-LD].
+--
+
+[.component,class=part]
+--
+The server MAY support the following additional content type: `application/xml`
+for link:https://www.w3.org/TR/2013/NOTE-prov-xml-20130430/[PROV-XML] as
+a link:https://www.w3.org/TR/2013/NOTE-prov-overview-20130430/[PROV] representation
+in XML using namespaces defined by the link:https://www.w3.org/TR/2013/REC-prov-dm-20130430/[PROV-DM] data model.
+--
+
+[.component,class=part]
+--
+The server MAY support the following additional content type: `text/provenance-notation`
+for link:https://www.w3.org/TR/2013/REC-prov-n-20130430/[PROV-N] as
+a human-readable provenance notation
+of the link:https://www.w3.org/TR/2013/REC-prov-dm-20130430/[PROV-DM] data model.
+--
+
+[.component,class=part]
+--
+The server MAY support the following additional content type: `application/n-triples`
+for PROV-NT as link:https://www.w3.org/TR/n-triples/[N-Triples RDF]
+using the link:https://www.w3.org/TR/2013/REC-prov-o-20130430/[PROV-O] RDF ontology.
+--
+
+[.component,class=part]
+--
+The server MAY support the following additional content type: `text/turtle`
+for PROV-TURTLE as link:https://www.w3.org/TR/rdf12-turtle/[Turtle RDF]
+using the link:https://www.w3.org/TR/2013/REC-prov-o-20130430/[PROV-O] RDF ontology.
+--
+
+[.component,class=part]
+--
+For all supported content media-types, the server MAY support
+link:https://datatracker.ietf.org/doc/html/rfc2616#section-12["Content Negotiation"] of the Provenance
+representation either through the https://www.rfc-editor.org/rfc/rfc2616#section-14.1[HTTP Accept] header,
+the `f` query parameter, by link:https://docs.ogc.org/DRAFTS/18-062r3.html#con-neg-by-profile["Profile"]
+or any other mechanism it deems fit.
+--
+
 ====

--- a/extensions/job_management/standard/requirements/provenance/prov/REQ_response.adoc
+++ b/extensions/job_management/standard/requirements/provenance/prov/REQ_response.adoc
@@ -2,8 +2,23 @@
 [requirement]
 ====
 [%metadata]
-label:: /req/provenance/prov-response
-part:: A successful execution of the operation SHALL be reported as a response with a HTTP status code '200'.
-part:: Per default, the response SHALL contains a JSON document that conforms to the https://www.w3.org/submissions/prov-json/schema[schema for PROV-JSON].
-part:: In case content-negotiation is used, the response MAY contain other representations including PROV-O as JSON-LD, PROV-XML or PROV-N.
+identifier:: /req/provenance/prov-response
+
+[.component,class=part]
+--
+A successful execution of the operation SHALL be reported as a response with a HTTP status code `200`.
+--
+
+[.component,class=part]
+--
+Per default, the response SHALL contains a JSON document that conforms to the
+link:https://www.w3.org/submissions/prov-json/schema[PROV-JSON] schema.
+--
+
+[.component,class=part]
+--
+In case content-negotiation is used, the response MAY contain other representations including but not limited to
+PROV-O as JSON-LD, PROV-XML or PROV-N. See also <<per_job-provenance_prov_content-negotiation,PROV Content Negotiation>>.
+--
+
 ====

--- a/extensions/job_management/standard/sections/annex_history.adoc
+++ b/extensions/job_management/standard/sections/annex_history.adoc
@@ -5,4 +5,5 @@
 |===
 |Date |Release |Editor | Primary clauses modified |Description
 |2024-08-22 |None |Gérald Fenoy |all |Boostraping the document
+|2026-04-09 |None |Francis Charette-Migneault |all |Improve listing and details of Job PROV alternate representations.
 |===


### PR DESCRIPTION
- uses format of #575 
- extend PROV formats that are already available and well-known from https://www.w3.org/TR/prov-overview/
- partially related to #576 