### PR TITLE
clarify the link between dismissed operations and job gone http errors

### DIFF
--- a/core/requirements/dismiss/REQ_job-dismiss-status.adoc
+++ b/core/requirements/dismiss/REQ_job-dismiss-status.adoc
@@ -16,4 +16,7 @@ If the job is currently in the `successful`, `failed` or `dismissed` state, then
 
 ====
 
-NOTE: This standard makes no statements regarding the disposition of artifacts created by a job once a job has been removed and is no longer accessible via the Processes API.
+NOTE: This standard makes no statements regarding the disposition strategy of artifacts created by a job once a job has been
+dismissed and is no longer accessible via the Processes API. Responses to dismissed jobs and their artifacts can
+optionally employ the corresponding <<per_core_job-results-exception_job-gone,/per/core/job-results-exception-job-gone>>
+and <<per_core_process-exception_job-gone,/per/core/process-exception-job-gone>> approaches to indicate their unavailability.

--- a/core/sections/clause_15_dismiss.adoc
+++ b/core/sections/clause_15_dismiss.adoc
@@ -4,6 +4,10 @@
 
 The Dismiss requirement class specifies how to dismiss a job.
 
+When a job is dismissed, the operation can include the cancellation of a pending or running job, the removal of
+artifacts from a running or finished job, a combination of both, and further data management procedures not specifically
+prescribed by this standard.
+
 include::../requirements/requirements_class_dismiss.adoc[]
 
 
@@ -30,7 +34,8 @@ include::../examples/json/StatusInfo-dismissed.json[]
 
 See <<http_status_codes>> for general guidance.
 
-If the process with the specified identifier does not exist on the server, the status code of the response SHALL be `404` (see <<req_core_process-exception-no-such-process,/req/core/process-exception/no-such-process>>).
+If the process with the specified identifier does not exist on the server, the status code of the response SHALL
+be `404` (see <<req_core_process-exception-no-such-process,/req/core/process-exception/no-such-process>>).
 
 If the job with the specified identifier does not exist, the status code of the
 response SHALL be `404` (see <<req_core_job-exception-no-such-job,/req/core/job-results-exception/no-such-job>>).


### PR DESCRIPTION
As it was reported during the SWG meeting on 2026-06-22, the *dismissed* operation manages both "removing the job" and "removing its artifacts" (and potentially more...). While the standard remains open to "how" to perform their "removal" to allow implementation flexibility (e.g.: actual delete, "hide / soft-delete" them, or a mixture of data management strategies), it was not really clear how "*HTTP 410 Gone*" status could be used to reflect the dismissed status of the job. Notably, the permissions are defined under the "Core" (section 7) which made them hard to identify in the context of "Dismissed" (section 14).

This makes the intention clearer with explicit links and a small introduction of what the operation is for. 