### PR TITLE
cleanup indents and git attributes for documented contents

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# data files
+[*.{yml,yaml,json,xml}]
+charset = utf-8
+indent_size = 2
+indent_style = space
+
+# code files
+[*.{sh}]
+charset = utf-8
+indent_size = 2
+indent_style = space

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto eol=lf
+
+# Ensures that GitHub detects non-programming files as content of the repository since code is not the main content
+# https://github.com/github-linguist/linguist/blob/main/docs/overrides.md#detectable
+*.adoc              linguist-detectable
+openapi/**/*.json   linguist-detectable
+openapi/**/*.yaml   linguist-detectable
+openapi/**/*.yml    linguist-detectable
+**/examples/*.json  linguist-detectable
+**/examples/*.yaml  linguist-detectable
+**/examples/*.yml   linguist-detectable

--- a/openapi/paths/processes-core/operations/oJobResults.yaml
+++ b/openapi/paths/processes-core/operations/oJobResults.yaml
@@ -5,10 +5,10 @@ description: |
    For more information, see [Section 7.11](https://docs.ogc.org/is/18-062r2/18-062r2.html#sc_retrieve_job_results).
 operationId: getResult
 tags:
-   - Jobs
+  - Jobs
 parameters:
-   - $ref: "../../../parameters/processes-core/jobID.yaml"
-   - $ref: "../../../parameters/processes-core/prefer-header-return.yaml"
+  - $ref: "../../../parameters/processes-core/jobID.yaml"
+  - $ref: "../../../parameters/processes-core/prefer-header-return.yaml"
 responses:
    200:
       $ref: "../../../responses/processes-core/rResults.yaml"

--- a/openapi/paths/processes-core/operations/oProcessList.yaml
+++ b/openapi/paths/processes-core/operations/oProcessList.yaml
@@ -5,8 +5,8 @@ description: |
    For more information, see [Section 7.7]https://docs.ogc.org/is/18-062r2/18-062r2.html#sc_process_list).
 operationId: getProcesses
 tags:
-   - Processes
-   - Core
+  - Processes
+  - Core
 responses:
    200:
       $ref: "../../../responses/processes-core/rProcessList.yaml"

--- a/openapi/responses/processes-core/rExecuteSync.yaml
+++ b/openapi/responses/processes-core/rExecuteSync.yaml
@@ -30,7 +30,7 @@ content:
   application/geo+json:
     schema:
       allOf:
-         - format: geojson-feature-collection
-         # JSON Schema not supported in OpenAPI 3.0
-         # - $ref: https://geojson.org/schema/FeatureCollection.json
-         - $ref: '../../schemas/geojson/FeatureCollection.yaml'
+        - format: geojson-feature-collection
+        # JSON Schema not supported in OpenAPI 3.0
+        # - $ref: https://geojson.org/schema/FeatureCollection.json
+        - $ref: '../../schemas/geojson/FeatureCollection.yaml'

--- a/openapi/schemas/common-geodata/additionalDimensionExtent.yaml
+++ b/openapi/schemas/common-geodata/additionalDimensionExtent.yaml
@@ -2,9 +2,9 @@ title: Extent of any additional dimensions
 description: The domain intervals for any additional dimensions of the extent (envelope) beyond those described in temporal and spatial.
 type: object
 oneOf:
-   - required: [ interval, definition ]
-   - required: [ interval, trs ]
-   - required: [ interval, vrs ]
+  - required: [ interval, definition ]
+  - required: [ interval, trs ]
+  - required: [ interval, vrs ]
 properties:
    interval:
      title: Interval of the extent of this dimension
@@ -26,11 +26,11 @@ properties:
        maxItems: 2
        items:
          oneOf:
-            - type: string
-              nullable: true
-              example: '2011-11-11T12:22:11Z' #, '2011-11-11T08:22:11-04:00', null
-            - type: number
-              example: 32.7
+           - type: string
+             nullable: true
+             example: '2011-11-11T12:22:11Z' #, '2011-11-11T08:22:11-04:00', null
+           - type: number
+             example: 32.7
    trs:
      title: Temporal Coordinate Reference System
      description: Temporal Coordinate Reference System (e.g. as defined by Features for 'temporal'). This should be a URI to a registered TRS if one is available, or a full description of the TRS otherwise using e.g., a WKT2CRS string, or a PROJJSON, or CRS JSON object.

--- a/openapi/schemas/common-geodata/dataType.yaml
+++ b/openapi/schemas/common-geodata/dataType.yaml
@@ -1,8 +1,8 @@
 # This list may be extended (e.g. point clouds, meshes)
 anyOf:
- - type: string
- - type: string
-   enum:
-   - map
-   - vector
-   - coverage
+  - type: string
+  - type: string
+    enum:
+      - map
+      - vector
+      - coverage

--- a/openapi/schemas/common-geodata/extent-UAD.yaml
+++ b/openapi/schemas/common-geodata/extent-UAD.yaml
@@ -1,15 +1,15 @@
 title: Extent conforming to Uniform Additional Dimensions Schema
 description: |-
-   The extent of the data in the collection.
-   This extent schema requires that if any dimension beyond spatial and temporal are specified, they conform to the Uniform Additional Dimensions schema.
-   In addition to the spatial and temporal extents defined in the "Collections" requirements class of OGC API - Common - Part 2,
-   the "Uniform Additional Dimensions" requirements class specifies a generic schema for describing any additional dimension, such as thermal or pressure ranges.
+  The extent of the data in the collection.
+  This extent schema requires that if any dimension beyond spatial and temporal are specified, they conform to the Uniform Additional Dimensions schema.
+  In addition to the spatial and temporal extents defined in the "Collections" requirements class of OGC API - Common - Part 2,
+  the "Uniform Additional Dimensions" requirements class specifies a generic schema for describing any additional dimension, such as thermal or pressure ranges.
 allOf:
-   - type: object
-     properties:
-        spatial:
-          $ref: 'spatialExtent.yaml'
-        temporal:
-          $ref: 'temporalExtent.yaml'
-     additionalProperties:
-        $ref: 'additionalDimensionExtent.yaml'
+  - type: object
+    properties:
+      spatial:
+        $ref: 'spatialExtent.yaml'
+      temporal:
+        $ref: 'temporalExtent.yaml'
+    additionalProperties:
+      $ref: 'additionalDimensionExtent.yaml'

--- a/openapi/schemas/common-geodata/extent.yaml
+++ b/openapi/schemas/common-geodata/extent.yaml
@@ -1,19 +1,19 @@
 title: Extent with (optional) Uniform Additional Dimensions Schema
 description: |-
-   The extent of the data in the collection.
-   This extent schema includes optional additional dimensions, but will still validate for objects not conforming to UAD.
-   OGC API - Common - Part 2 "Collections" requirements class specifies only the definition of the spatial and temporal extents.
-   The "Uniform Additional Dimensions" requirements class specifies a generic schema for describing any additional dimension, such as thermal or pressure ranges.
+  The extent of the data in the collection.
+  This extent schema includes optional additional dimensions, but will still validate for objects not conforming to UAD.
+  OGC API - Common - Part 2 "Collections" requirements class specifies only the definition of the spatial and temporal extents.
+  The "Uniform Additional Dimensions" requirements class specifies a generic schema for describing any additional dimension, such as thermal or pressure ranges.
 allOf:
-   - type: object
-     properties:
-        spatial:
-          $ref: 'spatialExtent.yaml'
-        temporal:
-          $ref: 'temporalExtent.yaml'
-   - anyOf:
-     - type: object
-       description: General object extension point
-     - type: object
-       additionalProperties:
+  - type: object
+    properties:
+      spatial:
+        $ref: 'spatialExtent.yaml'
+      temporal:
+        $ref: 'temporalExtent.yaml'
+  - anyOf:
+      - type: object
+        description: General object extension point
+      - type: object
+        additionalProperties:
           $ref: 'additionalDimensionExtent.yaml'

--- a/openapi/schemas/cql2/cql2-definitions.yaml
+++ b/openapi/schemas/cql2/cql2-definitions.yaml
@@ -94,10 +94,10 @@ definitions:
     #  - $ref: '#/definitions/patternExpression'
     items:
       oneOf:
-          - $ref: '#/definitions/characterExpression'
-          - $ref: '#/definitions/propertyRef'
-          - $ref: '#/definitions/functionRef'
-          - $ref: '#/definitions/patternExpression'
+        - $ref: '#/definitions/characterExpression'
+        - $ref: '#/definitions/propertyRef'
+        - $ref: '#/definitions/functionRef'
+        - $ref: '#/definitions/patternExpression'
   patternExpression:
     oneOf:
       - type: object

--- a/openapi/schemas/crs/crs.yaml
+++ b/openapi/schemas/crs/crs.yaml
@@ -16,8 +16,8 @@ oneOf:
     properties:
       wkt:
         allOf:
-           - description: An object defining the CRS using the JSON encoding for Well-known text representation of coordinate reference systems 2.0
-           - type: object # - $ref: 'projJSON.yaml'
+          - description: An object defining the CRS using the JSON encoding for Well-known text representation of coordinate reference systems 2.0
+          - type: object # - $ref: 'projJSON.yaml'
   - required:
     - referenceSystem
     properties:

--- a/openapi/schemas/crs/projJSON.yaml
+++ b/openapi/schemas/crs/projJSON.yaml
@@ -815,12 +815,12 @@ definitions:
             - datum
             - datum_ensemble
       - oneOf:
-          - type: object
-            required:
-              - datum
-          - type: object
-            required:
-              - datum_ensemble
+        - type: object
+          required:
+            - datum
+        - type: object
+          required:
+            - datum_ensemble
   object_usage:
     anyOf:
       - type: object

--- a/openapi/schemas/cwl/cwl-json-schema.yaml
+++ b/openapi/schemas/cwl/cwl-json-schema.yaml
@@ -1424,114 +1424,114 @@ $defs:
       Nested type and multi-type definitions will validate against 'Any'.
     oneOf:
        # 1. Null / Explicitly empty
-       - type: object
-         properties:
-           type:
-             type : string
-             enum: ['null']
-           default:
-             #type: string
-             nullable: true
-             enum: [null]
-         required: [type]
+      - type: object
+        properties:
+          type:
+            type : string
+            enum: ['null']
+          default:
+            #type: string
+            nullable: true
+            enum: [null]
+        required: [type]
 
-       # 2. Strings & Optional Strings
-       - type: object
-         properties:
-           type:
-             type: string
-             enum: [string, 'string?']
-           default:
-             type: string
-             nullable: true
-         required: [type]
+      # 2. Strings & Optional Strings
+      - type: object
+        properties:
+          type:
+            type: string
+            enum: [string, 'string?']
+          default:
+            type: string
+            nullable: true
+        required: [type]
 
-       # 3. Booleans
-       - type: object
-         properties:
-           type:
-             type: string
-             enum: [boolean, 'boolean?']
-           default:
-             type: boolean
-             nullable: true
-         required: [type]
+      # 3. Booleans
+      - type: object
+        properties:
+          type:
+            type: string
+            enum: [boolean, 'boolean?']
+          default:
+            type: boolean
+            nullable: true
+        required: [type]
 
-       # 4. Numeric Types (Int, Long, Float, Double)
-       - type: object
-         properties:
-           type:
-             type: string
-             enum: [int, 'int?', long, 'long?', float, 'float?', double, 'double?', integer, 'integer?']
-           default:
-             type: number
-             nullable: true
-         required: [type]
+      # 4. Numeric Types (Int, Long, Float, Double)
+      - type: object
+        properties:
+          type:
+            type: string
+            enum: [int, 'int?', long, 'long?', float, 'float?', double, 'double?', integer, 'integer?']
+          default:
+            type: number
+            nullable: true
+        required: [type]
 
-       # 5. File & Directory (Special CWL Objects)
-       - type: object
-         properties:
-           type:
-             type: string
-             enum: [File, 'File?', Directory, 'Directory?']
-           default:
-             oneOf:
-               - $ref: '#/$defs/CWLDefaultLocation'
-               - nullable: true
-                 enum: [null]
-                 #type: string
-         required: [type]
+      # 5. File & Directory (Special CWL Objects)
+      - type: object
+        properties:
+          type:
+            type: string
+            enum: [File, 'File?', Directory, 'Directory?']
+          default:
+            oneOf:
+              - $ref: '#/$defs/CWLDefaultLocation'
+              - nullable: true
+                enum: [null]
+                #type: string
+        required: [type]
 
-       # 6. Arrays (Shorthand: string[], int[], etc.)
-       - type: object
-         properties:
-           type:
-             type: string
-             pattern: '^[a-zA-Z]+\\[\\]$' # Matches any 'type[]' shorthand
-           default:
-             type: array
-             items:
-               $ref: '#/$defs/AnyType'
-         required: [type]
+      # 6. Arrays (Shorthand: string[], int[], etc.)
+      - type: object
+        properties:
+          type:
+            type: string
+            pattern: '^[a-zA-Z]+\\[\\]$' # Matches any 'type[]' shorthand
+          default:
+            type: array
+            items:
+              $ref: '#/$defs/AnyType'
+        required: [type]
 
-       # 7. Complex Arrays (type: array + items)
-       - type: object
-         properties:
-           type:
-             type: string
-             enum: [array]
-           items:
-             $ref: '#/$defs/AnyType'
-           default:
-             type: array
-             items:
-               $ref: '#/$defs/AnyType'
-         required: [type, items]
+      # 7. Complex Arrays (type: array + items)
+      - type: object
+        properties:
+          type:
+            type: string
+            enum: [array]
+          items:
+            $ref: '#/$defs/AnyType'
+          default:
+            type: array
+            items:
+              $ref: '#/$defs/AnyType'
+        required: [type, items]
 
-       # 8. Enums (type: enum + symbols)
-       - type: object
-         properties:
-           type:
-             type: string
-             enum: [enum, 'enum?']
-           symbols:
-             type: array
-             items:
-               type: string
-           default:
-             type: string
-             nullable: true
-         required: [type, symbols]
+      # 8. Enums (type: enum + symbols)
+      - type: object
+        properties:
+          type:
+            type: string
+            enum: [enum, 'enum?']
+          symbols:
+            type: array
+            items:
+              type: string
+          default:
+            type: string
+            nullable: true
+        required: [type, symbols]
 
-       # 9. Global Fallback (Any)
-       - type: object
-         properties:
-           type:
-             type: string
-             enum: [Any, 'Any?']
-           default:
-             $ref: '#/$defs/AnyType'
-         required: [type]
+      # 9. Global Fallback (Any)
+      - type: object
+        properties:
+          type:
+            type: string
+            enum: [Any, 'Any?']
+          default:
+            $ref: '#/$defs/AnyType'
+        required: [type]
 
   AnyType:
     oneOf:

--- a/openapi/schemas/processes-core/additionalParameter.yaml
+++ b/openapi/schemas/processes-core/additionalParameter.yaml
@@ -1,7 +1,7 @@
 type: object
 required:
-   - name
-   - value
+  - name
+  - value
 properties:
    name:
       type: string
@@ -9,9 +9,9 @@ properties:
       type: array
       items:
          oneOf:
-            - type: string
-            - type: number
-            - type: integer
-            - type: array
-              items: {}
-            - type: object
+           - type: string
+           - type: number
+           - type: integer
+           - type: array
+             items: {}
+           - type: object

--- a/openapi/schemas/processes-core/collectionValue.yaml
+++ b/openapi/schemas/processes-core/collectionValue.yaml
@@ -10,26 +10,26 @@ allOf:
            input values from the corresponding process input.  The server
            offering this collection is referred to as the "value source server".
         anyOf:
-           - type: string
-             description: |-
-               Collection identifier for a collection available at `{root}/collections/{collectionID}`, where `{root}` represents the landing page
-               of the process using the collection as an input (for the top-level process, that is the landing page of the process execution endpoint
-               to which the execution request is posted), or the landing page of the document being retrieved in the case of an output.
-               If the `collection` string includes a `/`, it must be interpreted as a URI reference rather than as a collection ID.
-           - type: string
-             description: |-
-                The URI of an OGC API collection.
-                If a relative URI reference is used, the Base URI is defined as such:
-                - For a Collection value received as input to a process, the Base URI is defined as the URI of the description
-                  (`{root}/processes/{processId}`) of that process, with the receiving process object understood as the Encapsulating Entity as per
-                  [RFC 3986 Section 5.1.2](https://datatracker.ietf.org/doc/html/rfc3986#section-5.1.2).
-                - For a Collection Output value, the Base URI is defined from the Retrieval URI as as per
-                  [RFC 3986 Section 5.1.3](https://datatracker.ietf.org/doc/html/rfc3986#section-5.1.3),
-                  for example, `/jobs/{jobId}/results`, `/jobs/{jobId}/results/{outputID}` or `/jobs/{jobId}/results/{outputID}/{N}` depending on the
-                  resource being retrieved.
-                If a collection string does not contain any `/`, it must not be interpreted as a URI reference, and must instead be resolved as a
-                collection identifier. For example, `countries` would resolve to `{root}/collections/countries` rather than `{root}/processes/countries`.
-             format: uri-reference
+          - type: string
+            description: |-
+              Collection identifier for a collection available at `{root}/collections/{collectionID}`, where `{root}` represents the landing page
+              of the process using the collection as an input (for the top-level process, that is the landing page of the process execution endpoint
+              to which the execution request is posted), or the landing page of the document being retrieved in the case of an output.
+              If the `collection` string includes a `/`, it must be interpreted as a URI reference rather than as a collection ID.
+          - type: string
+            description: |-
+               The URI of an OGC API collection.
+               If a relative URI reference is used, the Base URI is defined as such:
+               - For a Collection value received as input to a process, the Base URI is defined as the URI of the description
+                 (`{root}/processes/{processId}`) of that process, with the receiving process object understood as the Encapsulating Entity as per
+                 [RFC 3986 Section 5.1.2](https://datatracker.ietf.org/doc/html/rfc3986#section-5.1.2).
+               - For a Collection Output value, the Base URI is defined from the Retrieval URI as as per
+                 [RFC 3986 Section 5.1.3](https://datatracker.ietf.org/doc/html/rfc3986#section-5.1.3),
+                 for example, `/jobs/{jobId}/results`, `/jobs/{jobId}/results/{outputID}` or `/jobs/{jobId}/results/{outputID}/{N}` depending on the
+                 resource being retrieved.
+               If a collection string does not contain any `/`, it must not be interpreted as a URI reference, and must instead be resolved as a
+               collection identifier. For example, `countries` would resolve to `{root}/collections/countries` rather than `{root}/processes/countries`.
+            format: uri-reference
       bbox:
         description: |-
           Only resources that have a geometry that intersects the bounding box

--- a/openapi/schemas/processes-dru/outputBinding.yaml
+++ b/openapi/schemas/processes-dru/outputBinding.yaml
@@ -8,8 +8,8 @@ properties:
       . See inputBinding.yaml for referencing input values in an output
         binding "glob" expression.
     oneOf:
-       - type: string
-       - type: array
-         items:
-           type: string
+      - type: string
+      - type: array
+        items:
+          type: string
 additionalProperties: true

--- a/openapi/schemas/processes-job-management/statusInfo.yaml
+++ b/openapi/schemas/processes-job-management/statusInfo.yaml
@@ -1,8 +1,8 @@
 type: object
 required:
-   - id
-   - status
-   - processingEntityType
+  - id
+  - status
+  - processingEntityType
 properties:
    id:
       type: string

--- a/openapi/schemas/processes-workflows/execute-workflows.yaml
+++ b/openapi/schemas/processes-workflows/execute-workflows.yaml
@@ -1,31 +1,31 @@
 allOf:
-   - type: object
-     properties:
-        process:
-          type: string
-          format: uri-reference
-          description: |-
-             The URI to the description of the process that should be executed.
-             For the top-level process, when the execution request is POSTed to `{root}/processes/{processId}/execution`, this should be an absolute URI,
-             and the server should ignore this `process` key since the URI of the request already identifies the process to execute, and a client
-             is not required to resolve and replace the URI if passing a nested process block as part of a larger workflow executing a nested process.
-             If a relative URI reference is used, the Base URI is defined as the URI of the description
-             (`{root}/processes/{processId}`) of the receiving process, with this receiving process object understood as the
-             Encapsulating Entity as per [RFC 3986 Section 5.1.2](https://datatracker.ietf.org/doc/html/rfc3986#section-5.1.2).
-             In the case of a nested process on the same OGC API root as the receiving process, using a simple process ID as the relative URI reference
-             would resolve to a process available at `{root}/processes/{processID}`, where `{root}` represents the landing page of the receiving process.
-             For example, if a top-level process at https://example.com/processes/buffer receives a nested processs `{ "process": "clip" }`,
-             that clip process is resolved as https://example.com/processes/clip.
-        inputs:
-          additionalProperties:
-            $ref: "values-workflows.yaml"
-        outputs:
-          additionalProperties:
-            $ref: "outputSelection-workflows.yaml"
-        subscriber:
-          $ref: "../processes-core/subscriber.yaml"
-   - $ref: "../processes-core/fieldsModifiers.yaml"
-   - example:
+  - type: object
+    properties:
+      process:
+        type: string
+        format: uri-reference
+        description: |-
+          The URI to the description of the process that should be executed.
+          For the top-level process, when the execution request is POSTed to `{root}/processes/{processId}/execution`, this should be an absolute URI,
+          and the server should ignore this `process` key since the URI of the request already identifies the process to execute, and a client
+          is not required to resolve and replace the URI if passing a nested process block as part of a larger workflow executing a nested process.
+          If a relative URI reference is used, the Base URI is defined as the URI of the description
+          (`{root}/processes/{processId}`) of the receiving process, with this receiving process object understood as the
+          Encapsulating Entity as per [RFC 3986 Section 5.1.2](https://datatracker.ietf.org/doc/html/rfc3986#section-5.1.2).
+          In the case of a nested process on the same OGC API root as the receiving process, using a simple process ID as the relative URI reference
+          would resolve to a process available at `{root}/processes/{processID}`, where `{root}` represents the landing page of the receiving process.
+          For example, if a top-level process at https://example.com/processes/buffer receives a nested processs `{ "process": "clip" }`,
+          that clip process is resolved as https://example.com/processes/clip.
+      inputs:
+        additionalProperties:
+          $ref: "values-workflows.yaml"
+      outputs:
+        additionalProperties:
+          $ref: "outputSelection-workflows.yaml"
+      subscriber:
+        $ref: "../processes-core/subscriber.yaml"
+  - $ref: "../processes-core/fieldsModifiers.yaml"
+  - example:
       inputs:
         data:
           - collection: 'https://example.com/collections/sentinel2-l2a'

--- a/openapi/schemas/processes-workflows/inputParameterized.yaml
+++ b/openapi/schemas/processes-workflows/inputParameterized.yaml
@@ -1,8 +1,8 @@
 allOf:
- - type: object
-   required:
-     - $input
-   properties:
-     $input:
-       type: string
- - $ref: ../processes-core/fieldsModifiers.yaml
+  - type: object
+    required:
+      - $input
+    properties:
+      $input:
+        type: string
+  - $ref: ../processes-core/fieldsModifiers.yaml


### PR DESCRIPTION
- Adds `.gitattributes` to mark content of interest (https://github.com/github-linguist/linguist/blob/main/docs/overrides.md#detectable)
  Without this, the repository currently reports some odd statistics (as shown below) because those files are often used by CI/configs, and therefore ignored by default.

  <img width="300" alt="{6A415D44-F27D-4BC2-81D2-147EFA743A87}" src="https://github.com/user-attachments/assets/2eab592b-e399-423b-b4f9-e76ccc1de7d4" />

- unify openapi indents
  Because files where edited/imported in various ways, parsers have trouble dealing with the mixture of indents. Use the typical defaults for them (2-spaced indent style, and what most of the files already employed) to make it consistent.

- add `.editorconfig` to hint IDEs/text-editors supporting it to respect the desired indents
