### PR TITLE
fix redocly duplicate refs

### DIFF
--- a/.github/redocly/schema-name-prefix.plugin.js
+++ b/.github/redocly/schema-name-prefix.plugin.js
@@ -9,6 +9,24 @@
 
 // Store mapping of component objects to their source information
 const componentSourceMap = new WeakMap();
+const externalDefsRefMap = new WeakMap();
+const externalDefsComponents = new Map();
+
+const COMPONENT_FILE_PATTERN = /\/(schemas|responses|parameters|examples|requestBodies|headers|securitySchemes|links|callbacks)\/([^/]+)\/([^/]+)\.yaml$/;
+const EXTERNAL_DEFS_PATTERN = /(?:^|\/)schemas\/([^/]+)\/([^/#]+)\.yaml#\/\$defs\/([^/]+)$/;
+const DEBUG = process.env.REDOCLY_PLUGIN_DEBUG === "1";
+
+function parseExternalDefsRef(ref) {
+  if (typeof ref !== "string") {
+    return null;
+  }
+  const match = ref.match(EXTERNAL_DEFS_PATTERN);
+  if (!match) {
+    return null;
+  }
+  const [, directory, filename, defName] = match;
+  return { directory, filename, defName };
+}
 
 const PreserveComponentNamePrefixes = () => {
   return {
@@ -31,16 +49,53 @@ const PreserveComponentNamePrefixes = () => {
           return;
         }
 
-        // Extract directory and filename from various component paths:
-        // - schemas/{directory}/{filename}.yaml
-        // - responses/{directory}/{filename}.yaml
-        // - parameters/{directory}/{filename}.yaml
-        // etc.
-        const match = filePath.match(/\/(schemas|responses|parameters|examples|requestBodies|headers|securitySchemes|links|callbacks)\/([^\/]+)\/([^\/]+)\.yaml$/);
+        const defsRefMatch = parseExternalDefsRef(node.$ref);
+        if (defsRefMatch) {
+          const { directory, filename, defName } = defsRefMatch;
+          externalDefsRefMap.set(node, {
+            componentType: "schemas",
+            filename,
+            defName,
+            prefixedName: `${directory}-${defName}`
+          });
+          if (DEBUG) {
+            console.warn(`[schema-prefix] external defs ref: ${node.$ref} -> ${directory}-${defName}`);
+          }
+        }
+
+        // Extract directory and filename from various component paths.
+        const match = filePath.match(COMPONENT_FILE_PATTERN);
         if (match) {
           const [, componentType, directory, filename] = match;
 
-          if (directory && directory !== componentType) {
+          const pointer = location.pointer;
+          const defsPointerMatch =
+            componentType === "schemas" &&
+            typeof pointer === "string" &&
+            pointer.match(/^#\/\$defs\/([^/]+)$/);
+          if (defsPointerMatch) {
+            const [, defName] = defsPointerMatch;
+            const prefixedName = `${directory}-${defName}`;
+            componentSourceMap.set(node, {
+              componentType,
+              directory,
+              filename,
+              prefixedName
+            });
+            if (!externalDefsComponents.has(prefixedName)) {
+              externalDefsComponents.set(prefixedName, {
+                directory,
+                filename,
+                defName,
+                node
+              });
+              if (DEBUG) {
+                console.warn(`[schema-prefix] external defs node: ${filePath}${pointer} -> ${prefixedName}`);
+              }
+            }
+          }
+
+          if (directory && directory !== componentType && !defsPointerMatch) {
             // Store the source info for this node
             componentSourceMap.set(node, {
               componentType,
@@ -73,6 +128,8 @@ const PreserveComponentNamePrefixes = () => {
         ];
 
         const renameMap = new Map();
+        const refRenameMap = new Map();
+        const schemaTitleMap = new Map();
 
         // Process each component type
         for (const componentType of componentTypes) {
@@ -86,6 +143,17 @@ const PreserveComponentNamePrefixes = () => {
             const sourceInfo = componentSourceMap.get(componentContent);
 
             if (sourceInfo && sourceInfo.prefixedName) {
+              if (componentType === "schemas") {
+                // inject the original schema name as title to display it nicely in OpenAPI Swagger-UI
+                const prefix = `${sourceInfo.directory}-`;
+                const inferredTitle = sourceInfo.prefixedName.startsWith(prefix)
+                  ? sourceInfo.prefixedName.slice(prefix.length)
+                  : sourceInfo.prefixedName;
+                if (inferredTitle) {
+                  schemaTitleMap.set(sourceInfo.prefixedName, inferredTitle);
+                }
+              }
+
               // Only rename if the name differs
               if (componentName !== sourceInfo.prefixedName) {
                 const key = `${componentType}/${componentName}`;
@@ -94,6 +162,11 @@ const PreserveComponentNamePrefixes = () => {
                   oldName: componentName,
                   newName: sourceInfo.prefixedName
                 });
+
+                refRenameMap.set(
+                  `#/components/${componentType}/${componentName}`,
+                  `#/components/${componentType}/${sourceInfo.prefixedName}`
+                );
               }
             }
           }
@@ -108,31 +181,153 @@ const PreserveComponentNamePrefixes = () => {
           }
         }
 
+        const defsPrefixMap = new Map();
+        for (const [prefixedName, { directory, defName }] of externalDefsComponents.entries()) {
+          if (!defsPrefixMap.has(directory)) {
+            defsPrefixMap.set(directory, new Map());
+          }
+          defsPrefixMap.get(directory).set(defName, prefixedName);
+        }
+
+        function cloneAndRewriteDefsRefs(value, directory) {
+          if (Array.isArray(value)) {
+            return value.map((item) => cloneAndRewriteDefsRefs(item, directory));
+          }
+
+          if (!value || typeof value !== "object") {
+            return value;
+          }
+
+          const cloned = {};
+          for (const [key, item] of Object.entries(value)) {
+            if (key === "$ref" && typeof item === "string") {
+              const localDefsMatch = item.match(/^#\/\$defs\/([^/]+)$/);
+              if (localDefsMatch) {
+                const localDefs = defsPrefixMap.get(directory);
+                const defName = localDefsMatch[1];
+                if (localDefs && localDefs.has(defName)) {
+                  cloned[key] = `#/components/schemas/${localDefs.get(defName)}`;
+                  continue;
+                }
+              }
+            }
+            cloned[key] = cloneAndRewriteDefsRefs(item, directory);
+          }
+          return cloned;
+        }
+
+        const schemaComponents = root.components.schemas || (root.components.schemas = {});
+        for (const [prefixedName, { directory, defName, node }] of externalDefsComponents.entries()) {
+          if (!schemaComponents[prefixedName]) {
+            schemaComponents[prefixedName] = cloneAndRewriteDefsRefs(node, directory);
+          }
+          if (!schemaTitleMap.has(prefixedName) && defName) {
+            schemaTitleMap.set(prefixedName, defName);
+          }
+        }
+
+        for (const [schemaName, inferredTitle] of schemaTitleMap.entries()) {
+          const schema = schemaComponents[schemaName];
+          if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+            continue;
+          }
+          if (Object.prototype.hasOwnProperty.call(schema, "title")) {
+            continue;
+          }
+          schema.title = inferredTitle;
+        }
+
+        const canonicalRefMap = new Map();
+        for (const [prefixedName, { directory, filename, defName }] of externalDefsComponents.entries()) {
+          if (defName !== "CWL") {
+            continue;
+          }
+          const legacyName = `${directory}-${filename}`;
+          if (legacyName === prefixedName) {
+            continue;
+          }
+          if (schemaComponents[prefixedName]) {
+            canonicalRefMap.set(
+              `#/components/schemas/${legacyName}`,
+              `#/components/schemas/${prefixedName}`
+            );
+          }
+        }
+
+        if (DEBUG) {
+          console.warn(
+            `[schema-prefix] renameMap=${renameMap.size}, externalDefsComponents=${externalDefsComponents.size}`
+          );
+        }
+
         // Update all $ref occurrences throughout the document
-        function updateRefs(obj) {
+        function updateRefs(obj, opts = { skipCanonicalAlias: false }) {
           if (!obj || typeof obj !== 'object') {
             return;
           }
 
           if (obj.$ref && typeof obj.$ref === 'string') {
-            for (const [key, { componentType, oldName, newName }] of renameMap.entries()) {
-              const oldRef = `#/components/${componentType}/${oldName}`;
-              const newRef = `#/components/${componentType}/${newName}`;
-              if (obj.$ref === oldRef) {
-                obj.$ref = newRef;
+            const mappedExternalRef = externalDefsRefMap.get(obj);
+            if (mappedExternalRef) {
+              const promotedRef = `#/components/${mappedExternalRef.componentType}/${mappedExternalRef.prefixedName}`;
+              if (root.components[mappedExternalRef.componentType] &&
+                  root.components[mappedExternalRef.componentType][mappedExternalRef.prefixedName]) {
+                obj.$ref = promotedRef;
+              }
+            }
+
+            if (!opts.skipCanonicalAlias) {
+              const canonicalRef = canonicalRefMap.get(obj.$ref);
+              if (canonicalRef) {
+                obj.$ref = canonicalRef;
+              }
+            }
+
+            const renamedRef = refRenameMap.get(obj.$ref);
+            if (renamedRef) {
+              obj.$ref = renamedRef;
+            }
+
+            const externalDefsMatch = obj.$ref.match(EXTERNAL_DEFS_PATTERN);
+            if (externalDefsMatch) {
+              const [, directory, , defName] = externalDefsMatch;
+              const prefixedName = `${directory}-${defName}`;
+              if (root.components.schemas && root.components.schemas[prefixedName]) {
+                obj.$ref = `#/components/schemas/${prefixedName}`;
               }
             }
           }
 
           // Recursively update refs in nested objects
-          for (const value of Object.values(obj)) {
+          for (const [key, value] of Object.entries(obj)) {
             if (value && typeof value === 'object') {
-              updateRefs(value);
+              const skipCanonicalAlias =
+                obj === schemaComponents &&
+                canonicalRefMap.has(`#/components/schemas/${key}`);
+              updateRefs(value, { skipCanonicalAlias });
             }
           }
         }
 
         updateRefs(root);
+
+        for (const [legacyRef, canonicalRef] of canonicalRefMap.entries()) {
+          const legacyName = legacyRef.replace("#/components/schemas/", "");
+          const legacySchema = schemaComponents[legacyName];
+          if (!legacySchema) {
+            continue;
+          }
+          const isSelfReferentialArray = (items) =>
+            Array.isArray(items) &&
+            items.length > 0 &&
+            items.every((entry) => entry && entry.$ref === legacyRef);
+          if (isSelfReferentialArray(legacySchema.allOf) || isSelfReferentialArray(legacySchema.oneOf)) {
+            delete schemaComponents[legacyName];
+            if (DEBUG) {
+              console.warn(`[schema-prefix] removed malformed legacy schema alias: ${legacyName} -> ${canonicalRef}`);
+            }
+          }
+        }
       }
     }
   };

--- a/.github/redocly/schema-name-prefix.plugin.js
+++ b/.github/redocly/schema-name-prefix.plugin.js
@@ -138,15 +138,13 @@ const PreserveComponentNamePrefixes = () => {
   };
 };
 
-module.exports = {
-  id: 'schema-prefix',
-  decorators: {
-    oas3: {
-      'preserve-schema-name-prefixes': PreserveComponentNamePrefixes,
+module.exports = function () {
+  return {
+    id: 'schema-prefix',
+    decorators: {
+      oas3: {
+        'preserve-schema-name-prefixes': PreserveComponentNamePrefixes,
+      }
     }
   }
 };
-
-
-
-

--- a/openapi/ogcapi-processes.bundled.json
+++ b/openapi/ogcapi-processes.bundled.json
@@ -787,6 +787,7 @@
   "components": {
     "schemas": {
       "CWLWorkflowStepWhen": {
+        "description": "Condition to execute a step that must evaluate to a boolean-like value.",
         "$ref": "#/components/schemas/cwl-cwl-json-schema"
       },
       "CQL2": {
@@ -1014,3113 +1015,6 @@
             }
           }
         }
-      },
-      "CWLVersion-2": {
-        "type": "object",
-        "properties": {
-          "cwlVersion": {
-            "type": "string",
-            "title": "cwlVersion",
-            "description": "CWL version of the described application package.",
-            "pattern": "^v\\d+(\\.\\d+(\\.\\d+)*)*$"
-          }
-        },
-        "required": [
-          "cwlVersion"
-        ]
-      },
-      "CWLMetadata-2": {
-        "type": "object",
-        "properties": {
-          "s:keywords": {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          },
-          "version": {
-            "type": "string",
-            "title": "version",
-            "description": "Version of the process.",
-            "example": "1.2.3",
-            "pattern": "^\\d+(\\.\\d+(\\.\\d+(\\.[A-Za-z0-9\\-_]+)*)*)*$"
-          }
-        }
-      },
-      "CWLDocumentation-2": {
-        "type": "object",
-        "properties": {
-          "label": {
-            "type": "string"
-          },
-          "doc": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            ]
-          }
-        }
-      },
-      "CWLTextPatternID": {
-        "$comment": "Identifier with text pattern that can allow additional non-ASCII characters depending on regex implementation.\nThe identifier allows a '#' or a relative 'sub/part#ref' prefix, to support references to other definitions\nin the CWL document, such as when using 'SchemaDefRequirement'.\n\nJSON spec regex does not include '\\w' in its default subset to allow all word-like unicode characters\n(see reference: https://json-schema.org/understanding-json-schema/reference/regular_expressions.html).\n\nSince support is implementation specific, add both the ASCII-only and '\\w' representation simultaneously\nand let the parser reading this document apply whichever is more relevant or supported\n(see discussion: https://github.com/common-workflow-language/cwl-v1.2/pull/256#discussion_r1234037814).\n",
-        "pattern": "^([A-Za-z0-9\\w]+(/[A-Za-z0-9\\w]+)*)?[#.]?[A-Za-z0-9\\w]+(?:[-_.][A-Za-z0-9\\w]+)*$",
-        "type": "string",
-        "description": "Generic identifier name pattern."
-      },
-      "CWLIdentifier": {
-        "anyOf": [
-          {
-            "type": "string",
-            "title": "UUID",
-            "description": "Unique identifier.",
-            "format": "uuid",
-            "pattern": "^[a-f0-9]{8}(?:-?[a-f0-9]{4}){3}-?[a-f0-9]{12}$"
-          },
-          {
-            "$ref": "#/components/schemas/CWLTextPatternID"
-          }
-        ],
-        "title": "CWLIdentifier",
-        "description": "Reference to the process identifier."
-      },
-      "cwltool:CUDARequirement": {
-        "type": "object",
-        "title": "cwltool:CUDARequirement",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "cwltool:CUDARequirement"
-            ]
-          },
-          "cudaVersionMin": {
-            "type": "string",
-            "title": "CUDA version minimum",
-            "description": "The minimum CUDA version required to run the software. This corresponds to a CUDA SDK release.\n\nWhen run in a container, the container image should provide the CUDA runtime,\nand the host driver is injected into the container.  In this case, because CUDA drivers\nare backwards compatible, it is possible to use an older SDK with a newer driver across major versions.\n\nSee https://docs.nvidia.com/deploy/cuda-compatibility/ for details.\n",
-            "example": "11.4",
-            "pattern": "^\\d+\\.\\d+$"
-          },
-          "cudaComputeCapability": {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          },
-          "cudaDeviceCountMin": {
-            "type": "integer",
-            "title": "CUDA device count minimum",
-            "description": "The minimum amount of devices required.",
-            "default": 1,
-            "example": 1,
-            "minimum": 1
-          },
-          "cudaDeviceCountMax": {
-            "type": "integer",
-            "title": "CUDA device count maximum",
-            "description": "The maximum amount of devices required.",
-            "default": 1,
-            "example": 8,
-            "minimum": 1
-          }
-        },
-        "required": [
-          "cudaVersionMin",
-          "cudaComputeCapability"
-        ],
-        "additionalProperties": false
-      },
-      "DockerRequirement-2": {
-        "type": "object",
-        "title": "DockerRequirement",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "DockerRequirement"
-            ]
-          },
-          "dockerPull": {
-            "type": "string",
-            "title": "Docker pull reference",
-            "description": "Reference package that will be retrieved and executed by CWL.",
-            "example": "docker-registry.host.com/namespace/image:1.2.3"
-          },
-          "dockerImport": {
-            "type": "string"
-          },
-          "dockerLoad": {
-            "type": "string"
-          },
-          "dockerFile": {
-            "type": "string"
-          },
-          "dockerImageId": {
-            "type": "string"
-          },
-          "dockerOutputDirectory": {
-            "type": "string"
-          }
-        },
-        "oneOf": [
-          {
-            "required": [
-              "dockerPull"
-            ]
-          },
-          {
-            "required": [
-              "dockerImport"
-            ]
-          },
-          {
-            "required": [
-              "dockerLoad"
-            ]
-          },
-          {
-            "required": [
-              "dockerFile"
-            ]
-          }
-        ],
-        "additionalProperties": false
-      },
-      "SoftwarePackage-2": {
-        "type": "object",
-        "properties": {
-          "package": {
-            "type": "string"
-          },
-          "version": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "specs": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/cwl-cwl-json-schema"
-            }
-          }
-        },
-        "required": [
-          "package"
-        ],
-        "additionalProperties": false
-      },
-      "SoftwarePackageSpecs-2": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "SoftwareRequirement-2": {
-        "type": "object",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "SoftwareRequirement"
-            ]
-          },
-          "packages": {
-            "oneOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/SoftwarePackage-2"
-                }
-              },
-              {
-                "type": "object",
-                "description": "Mapping of 'package' name to its specifications.",
-                "additionalProperties": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/SoftwarePackageSpecs-2"
-                    },
-                    {
-                      "$ref": "#/components/schemas/SoftwarePackage-2"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        },
-        "required": [
-          "packages"
-        ],
-        "additionalProperties": false
-      },
-      "ShellCommandRequirement-2": {
-        "type": "object",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "ShellCommandRequirement"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "CWLExpression-2": {
-        "$comment": "Whenever this option is applicable for a parameter, any other 'normal' string should not be specified.\nFor JSON schema validation, there is no easy way to distinguish them unless using complicated string patterns.\n",
-        "type": "string",
-        "title": "CWLExpression",
-        "description": "When combined with 'InlineJavascriptRequirement', this field allows runtime parameter references\n(see also: https://www.commonwl.org/v1.2/CommandLineTool.html#Expression).\n"
-      },
-      "EnvironmentDef-2": {
-        "type": "object",
-        "properties": {
-          "envName": {
-            "type": "string",
-            "minLength": 1
-          },
-          "envValue": {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          }
-        },
-        "required": [
-          "envName",
-          "envValue"
-        ],
-        "additionalProperties": false
-      },
-      "EnvVarRequirement-2": {
-        "type": "object",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "EnvVarRequirement"
-            ]
-          },
-          "envDef": {
-            "oneOf": [
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/EnvironmentDef-2"
-                }
-              },
-              {
-                "type": "object",
-                "description": "Mapping of 'envName' to environment value or definition.",
-                "additionalProperties": {
-                  "oneOf": [
-                    {
-                      "description": "The 'envValue' specified directly",
-                      "$ref": "#/components/schemas/CWLExpression-2"
-                    },
-                    {
-                      "$ref": "#/components/schemas/EnvironmentDef-2"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        },
-        "required": [
-          "envDef"
-        ],
-        "additionalProperties": false
-      },
-      "CWLTypeSymbols": {
-        "type": "array",
-        "title": "CWLTypeSymbols",
-        "summary": "Allowed values composing the enum.",
-        "items": {
-          "$ref": "#/components/schemas/cwl-cwl-json-schema"
-        }
-      },
-      "CWLTypeEnum-2": {
-        "type": "object",
-        "title": "CWLTypeEnum",
-        "summary": "CWL type as enum of values.",
-        "properties": {
-          "type": {
-            "type": "string",
-            "title": "type",
-            "example": "enum",
-            "enum": [
-              "enum"
-            ]
-          },
-          "symbols": {
-            "$ref": "#/components/schemas/CWLTypeSymbols"
-          }
-        },
-        "required": [
-          "type",
-          "symbols"
-        ],
-        "additionalProperties": {}
-      },
-      "CWLTypeDefinition-2": {
-        "type": "string",
-        "title": "CWL type string definition",
-        "summary": "CWL type string definition.",
-        "description": "Field type definition.",
-        "$comment": "Note that 'Any' is equivalent to any of the non-null types.\nTherefore, a nullable 'Any' explicitly specified by 'Any?' or its array-nullable form 'Any[]?' are not equivalent.\n",
-        "enum": [
-          "null",
-          "Any",
-          "Any?",
-          "Any[]",
-          "Any[]?",
-          "Directory",
-          "Directory?",
-          "Directory[]",
-          "Directory[]?",
-          "File",
-          "File?",
-          "File[]",
-          "File[]?",
-          "boolean",
-          "boolean?",
-          "boolean[]",
-          "boolean[]?",
-          "double",
-          "double?",
-          "double[]",
-          "double[]?",
-          "enum?",
-          "enum[]",
-          "enum[]?",
-          "float",
-          "float?",
-          "float[]",
-          "float[]?",
-          "int",
-          "int?",
-          "int[]",
-          "int[]?",
-          "integer",
-          "integer?",
-          "integer[]",
-          "integer[]?",
-          "long",
-          "long?",
-          "long[]",
-          "long[]?",
-          "string",
-          "string?",
-          "string[]",
-          "string[]?"
-        ]
-      },
-      "CWLType-2": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLTypeBase-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLTypeList-2"
-          }
-        ],
-        "title": "CWL Type"
-      },
-      "CWLTypeArray-2": {
-        "type": "object",
-        "title": "CWLTypeArray",
-        "summary": "CWL type as list of items.",
-        "properties": {
-          "type": {
-            "type": "string",
-            "title": "type",
-            "example": "array",
-            "enum": [
-              "array"
-            ]
-          },
-          "items": {
-            "$ref": "#/components/schemas/CWLType-2"
-          }
-        },
-        "required": [
-          "type",
-          "items"
-        ],
-        "additionalProperties": {}
-      },
-      "CWLInputStdInDefinition-2": {
-        "description": "Indicates that the value passed to this CWL input will be redirected to the standard input stream of the command.\nCan be defined for only one input and must not be combined with 'stdin' at the root of the CWL document.\n",
-        "type": "string",
-        "enum": [
-          "stdin"
-        ]
-      },
-      "CWLOutputStdOutDefinition-2": {
-        "description": "Indicates that the data pushed to the standard output stream by the command will be redirected to this CWL output.\nCan be defined for only one output. If combined with 'stdout' at the root of the CWL document, that definition\nwill indicate the desired name of the output file where the output stream will be written to. A random name will\nbe applied for the file of this output unless otherwise specified.\n",
-        "type": "string",
-        "enum": [
-          "stdout"
-        ]
-      },
-      "CWLOutputStdErrDefinition-2": {
-        "description": "Indicates that the data pushed to the standard error stream by the command will be redirected to this CWL output.\nCan be defined for only one output. If combined with 'stderr' at the root of the CWL document, that definition\nwill indicate the desired name of the output file where the error stream will be written to.  A random name will\nbe applied for the file of this output unless otherwise specified.\n",
-        "type": "string",
-        "enum": [
-          "stderr"
-        ]
-      },
-      "CWLTypeRecordRef-2": {
-        "description": "An IRI with minimally a '{Record}' identifier to look for a schema definition locally or remotely.\n\nThe identifier resolution is performed accordingly to the specified reference and as described in\nhttps://www.commonwl.org/v1.2/SchemaSalad.html#Identifier_resolution.\n",
-        "$comment": "Avoid 'oneOf' conflict of valid strings between this CWL record reference and the generic CWL types.",
-        "allOf": [
-          {
-            "not": {
-              "$ref": "#/components/schemas/CWLTypeDefinition-2"
-            }
-          },
-          {
-            "not": {
-              "$ref": "#/components/schemas/CWLInputStdInDefinition-2"
-            }
-          },
-          {
-            "not": {
-              "$ref": "#/components/schemas/CWLOutputStdOutDefinition-2"
-            }
-          },
-          {
-            "not": {
-              "$ref": "#/components/schemas/CWLOutputStdErrDefinition-2"
-            }
-          },
-          {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          }
-        ]
-      },
-      "CWLTypeRecordSchema-2": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "record"
-            ]
-          },
-          "fields": {
-            "$ref": "#/components/schemas/CWLTypeRecordFields-2"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "CWLTypeBase-2": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLTypeDefinition-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLTypeArray-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLTypeEnum-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLTypeRecordRef-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLTypeRecordSchema-2"
-          }
-        ],
-        "title": "CWLTypeBase"
-      },
-      "CWLTypeList-2": {
-        "type": "array",
-        "title": "CWLTypeList",
-        "summary": "Combination of allowed CWL types.",
-        "items": {
-          "$ref": "#/components/schemas/CWLTypeBase-2"
-        }
-      },
-      "CWLTypeRecordFieldDefBase-2": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "$comment": "Required if list item. Otherwise, optional since it is the mapping key.\nThis requirement is defined in 'CWLTypeRecordFieldsItem' to allow reuse of this schema.\n",
-            "type": "string"
-          },
-          "type": {
-            "$ref": "#/components/schemas/CWLType-2"
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "CWLFileOnlyParametersConditional-2": {
-        "description": "Parameters that are only valid when 'type' or 'items' evaluates to 'File'.",
-        "$comment": "Explicitly disallow these parameters when non-File type is detected.\nOtherwise, validate their schema definitions according to what is permitted.\n",
-        "type": "object",
-        "if": {
-          "properties": {
-            "oneOf": [
-              {
-                "$comment": "Single required or optional 'File'.",
-                "type": {
-                  "enum": [
-                    "File",
-                    "File?",
-                    "File[]",
-                    "File[]?"
-                  ]
-                }
-              },
-              {
-                "$comment": "Array of required or optional 'File'.",
-                "type": {
-                  "const": "array"
-                },
-                "items": {
-                  "oneOf": [
-                    {
-                      "type": [
-                        {
-                          "const": "File"
-                        },
-                        {
-                          "const": "File?"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "array",
-                      "contains": {
-                        "type": [
-                          {
-                            "const": "File"
-                          },
-                          {
-                            "const": "File?"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        },
-        "then": {
-          "$ref": "#/$defs/CWLFileOnlyParameters"
-        },
-        "else": {
-          "not": {
-            "properties": {
-              "secondaryFiles": {},
-              "streamable": {},
-              "format": {},
-              "loadContents": {}
-            }
-          }
-        }
-      },
-      "CWLDirectoryOnlyParametersConditional-2": {
-        "description": "Parameters that are only valid when 'type' or 'items' evaluates to 'Directory'.",
-        "$comment": "Explicitly disallow these parameters when non-Directory type is detected.\nOtherwise, validate their schema definitions according to what is permitted.\n",
-        "type": "object",
-        "if": {
-          "properties": {
-            "oneOf": [
-              {
-                "$comment": "Single required or optional 'Directory'.",
-                "type": {
-                  "enum": [
-                    "Directory",
-                    "Directory?",
-                    "Directory[]",
-                    "Directory[]?"
-                  ]
-                }
-              },
-              {
-                "$comment": "Array of required or optional 'Directory'.",
-                "type": {
-                  "const": "array"
-                },
-                "items": {
-                  "oneOf": [
-                    {
-                      "type": [
-                        {
-                          "const": "Directory"
-                        },
-                        {
-                          "const": "Directory?"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "array",
-                      "contains": {
-                        "type": [
-                          {
-                            "const": "Directory"
-                          },
-                          {
-                            "const": "Directory?"
-                          }
-                        ]
-                      }
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        },
-        "then": {
-          "$ref": "#/$defs/CWLDirectoryOnlyParameters"
-        },
-        "else": {
-          "not": {
-            "properties": {
-              "loadListing": {}
-            }
-          }
-        }
-      },
-      "CWLTypeRecordFieldDef-2": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLTypeRecordFieldDefBase-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLFileOnlyParametersConditional-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLDirectoryOnlyParametersConditional-2"
-          }
-        ]
-      },
-      "CWLTypeRecordFieldsMap-2": {
-        "type": "object",
-        "additionalProperties": {
-          "oneOf": [
-            {
-              "$ref": "#/components/schemas/CWLType-2"
-            },
-            {
-              "$ref": "#/components/schemas/CWLTypeRecordFieldDef-2"
-            }
-          ]
-        }
-      },
-      "CWLTypeRecordFieldsItem": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLTypeRecordFieldDef-2"
-          },
-          {
-            "required": [
-              "name"
-            ]
-          }
-        ]
-      },
-      "CWLTypeRecordFieldsList-2": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/CWLTypeRecordFieldsItem"
-        }
-      },
-      "CWLTypeRecordFields-2": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLTypeRecordFieldsMap-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLTypeRecordFieldsList-2"
-          }
-        ]
-      },
-      "CWLTypeRecordArray-2": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "array"
-            ]
-          },
-          "items": {
-            "$ref": "#/components/schemas/CWLType-2"
-          }
-        },
-        "required": [
-          "type",
-          "items"
-        ]
-      },
-      "CWLImport-2": {
-        "description": "Represents an '$import' directive that should point toward another compatible CWL file to import where specified.\nThe contents of the imported file should be relevant contextually where it is being imported.\n",
-        "$comment": "The schema validation of the CWL will not itself perform the '$import' to resolve and validate its contents.\nTherefore, the complete schema will not be validated entirely, and could still be partially malformed.\nTo ensure proper and exhaustive validation of a CWL definition with this schema, all '$import' directives\nshould be resolved and extended beforehand.\n",
-        "type": "object",
-        "properties": {
-          "$import": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "$import"
-        ],
-        "additionalProperties": false
-      },
-      "SchemaDefRequirement-2": {
-        "type": "object",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "SchemaDefRequirement"
-            ]
-          },
-          "types": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/CWLTypeEnum-2"
-                },
-                {
-                  "$ref": "#/components/schemas/CWLTypeRecordSchema-2"
-                },
-                {
-                  "$ref": "#/components/schemas/CWLTypeRecordArray-2"
-                },
-                {
-                  "$ref": "#/components/schemas/CWLImport-2"
-                }
-              ]
-            }
-          }
-        },
-        "required": [
-          "types"
-        ],
-        "additionalProperties": false
-      },
-      "NullableType": {
-        "description": "Define a 'null' type that is JSON-schema compliant and helps OpenAPI 3.0 backport compatibility.",
-        "enum": [
-          null
-        ],
-        "nullable": true
-      },
-      "DirectoryListingDirent-2": {
-        "$comment": "Called 'Dirent' in documentation.",
-        "type": "object",
-        "title": "DirectoryListingDirent",
-        "properties": {
-          "entry": {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          },
-          "entryname": {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          },
-          "writable": {
-            "type": "boolean"
-          }
-        },
-        "required": [
-          "entry"
-        ],
-        "additionalProperties": false
-      },
-      "Checksum": {
-        "$comment": "Minimal pattern check to know which hash algorithm to apply,\nbut don't check too harshly for the rest (length, allowed characters, etc.).\n",
-        "type": "string",
-        "pattern": "^[a-z0-9\\-]+\\$[\\w\\-.]+$"
-      },
-      "DirectoryListingFileOrDirectory-2": {
-        "type": "object",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "File",
-              "Directory"
-            ]
-          },
-          "location": {
-            "type": "string"
-          },
-          "checksum": {
-            "$ref": "#/components/schemas/Checksum"
-          },
-          "size": {
-            "type": "integer",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "class",
-          "location"
-        ],
-        "additionalProperties": false
-      },
-      "InitialWorkDirListing-2": {
-        "title": "InitialWorkDirListing",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          },
-          {
-            "type": "array",
-            "title": "InitialWorkDirListingItems",
-            "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/NullableType"
-                },
-                {
-                  "$ref": "#/components/schemas/CWLExpression-2"
-                },
-                {
-                  "$ref": "#/components/schemas/DirectoryListingDirent-2"
-                },
-                {
-                  "$ref": "#/components/schemas/DirectoryListingFileOrDirectory-2"
-                },
-                {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DirectoryListingFileOrDirectory-2"
-                  }
-                }
-              ]
-            }
-          }
-        ]
-      },
-      "InitialWorkDirRequirement-2": {
-        "type": "object",
-        "title": "InitialWorkDirRequirement",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "InitialWorkDirRequirement"
-            ]
-          },
-          "listing": {
-            "$ref": "#/components/schemas/InitialWorkDirListing-2"
-          }
-        },
-        "required": [
-          "listing"
-        ],
-        "additionalProperties": false
-      },
-      "InlineJavascriptRequirement-2": {
-        "type": "object",
-        "title": "InlineJavascriptRequirement",
-        "description": "Indicates that the workflow platform must support inline Javascript expressions.\n\nIf this requirement is not present, the workflow platform must not perform expression interpolation\n(see also: https://www.commonwl.org/v1.2/CommandLineTool.html#InlineJavascriptRequirement).\n",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "InlineJavascriptRequirement"
-            ]
-          },
-          "expressionLib": {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          }
-        },
-        "additionalProperties": false
-      },
-      "InplaceUpdateRequirement-2": {
-        "type": "object",
-        "title": "InplaceUpdateRequirement",
-        "description": "If 'inplaceUpdate' is true, then an implementation supporting this feature may permit tools to directly\nupdate files with 'writable: true' in 'InitialWorkDirRequirement'. That is, as an optimization,\nfiles may be destructively modified in place as opposed to copied and updated\n(see also: https://www.commonwl.org/v1.2/CommandLineTool.html#InplaceUpdateRequirement).\n",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "InplaceUpdateRequirement"
-            ]
-          },
-          "inplaceUpdate": {
-            "type": "boolean",
-            "title": "inplaceUpdate"
-          }
-        },
-        "required": [
-          "inplaceUpdate"
-        ],
-        "additionalProperties": false
-      },
-      "LoadListingRequirement-2": {
-        "type": "object",
-        "title": "LoadListingRequirement",
-        "description": "Specify the desired behavior for loading the listing field of a 'Directory' object for use by expressions\n(see also: https://www.commonwl.org/v1.2/CommandLineTool.html#LoadListingRequirement).\n",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "LoadListingRequirement"
-            ]
-          },
-          "loadListing": {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          }
-        },
-        "required": [
-          "loadListing"
-        ],
-        "additionalProperties": false
-      },
-      "NetworkAccess-2": {
-        "title": "NetworkAccess",
-        "description": "Indicate whether a process requires outgoing IPv4/IPv6 network access.",
-        "example": true,
-        "oneOf": [
-          {
-            "type": "boolean"
-          },
-          {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          }
-        ]
-      },
-      "NetworkAccessRequirement-2": {
-        "type": "object",
-        "title": "NetworkAccessRequirement",
-        "properties": {
-          "class": {
-            "type": "string",
-            "$comment": "Not 'NetworkAccessRequirement'",
-            "enum": [
-              "NetworkAccess"
-            ]
-          },
-          "networkAccess": {
-            "$ref": "#/components/schemas/NetworkAccess-2"
-          }
-        },
-        "required": [
-          "networkAccess"
-        ],
-        "additionalProperties": false
-      },
-      "ResourceQuantityOrFractional-2": {
-        "description": "An item quantity that can also represent a proportion of use by resources.",
-        "$comment": "Technically should be minimum=1, but fractional for scheduling algorithms are allowed.\nThere is no way to distinguish between float/long simultaneously in JSON schema (multi-match oneOf).\nTherefore, only validate that it is greater than zero.\n",
-        "type": "number",
-        "default": 1,
-        "minimum": 0
-      },
-      "ResourceCoresMinimum": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/ResourceQuantityOrFractional-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          }
-        ],
-        "title": "ResourceCoresMinimum",
-        "summary": "Minimum reserved number of CPU cores.",
-        "description": "Minimum reserved number of CPU cores.\n\nMay be a fractional value to indicate to a scheduling algorithm that one core can be allocated to\nmultiple jobs. For example, a value of 0.25 indicates that up to 4 jobs\nmay run in parallel on 1 core. A value of 1.25 means that up to 3 jobs\ncan run on a 4 core system (4/1.25 ~ 3).\n\nProcesses can only share a core allocation if the sum of each of their 'ramMax', 'tmpdirMax', and\n'outdirMax' requests also do not exceed the capacity of the node.\n\nProcesses sharing a core must have the same level of isolation (typically a container\nor VM) that they would normally have.\n\nThe reported number of CPU cores reserved for the process, which is available to expressions\non the 'CommandLineTool' as 'runtime.cores', must be a non-zero integer, and may be calculated by\nrounding up the cores request to the next whole number.\n\nScheduling systems may allocate fractional CPU resources by setting quotas or scheduling weights.\nScheduling systems that do not support fractional CPUs may round up the request to the next whole number.\n",
-        "default": 1
-      },
-      "ResourceCoresMaximum": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/ResourceQuantityOrFractional-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          }
-        ],
-        "title": "ResourceCoresMaximum",
-        "summary": "Maximum reserved number of CPU cores.",
-        "description": "Maximum reserved number of CPU cores.\nSee 'coresMin' for discussion about fractional CPU requests.\n"
-      },
-      "ResourceRAMMinimum": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/ResourceQuantityOrFractional-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          }
-        ],
-        "title": "ResourceRAMMinimum",
-        "summary": "Minimum reserved RAM in mebibytes.",
-        "description": "Minimum reserved RAM in mebibytes (2**20).\n\nMay be a fractional value. If so, the actual RAM request must be rounded up\nto the next whole number.\n\nThe reported amount of RAM reserved for the process, which is available to\nexpressions on the 'CommandLineTool' as 'runtime.ram', must be a non-zero integer.\n",
-        "default": 256
-      },
-      "ResourceRAMMaximum": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/ResourceQuantityOrFractional-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          }
-        ],
-        "title": "ResourceRAMMaximum",
-        "summary": "Maximum reserved RAM in mebibytes.",
-        "description": "Maximum reserved RAM in mebibytes (2**20).\nSee 'ramMin' for discussion about fractional RAM requests.\n"
-      },
-      "ResourceTmpDirMinimum": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/ResourceQuantityOrFractional-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          }
-        ],
-        "title": "ResourceTmpDirMinimum",
-        "summary": "Minimum reserved filesystem based storage for the designated temporary directory in mebibytes.",
-        "description": "Minimum reserved filesystem based storage for the designated temporary\ndirectory in mebibytes (2**20).\n\nMay be a fractional value. If so, the actual storage request must be rounded\nup to the next whole number.\n\nThe reported amount of storage reserved for the process, which is available\nto expressions on the 'CommandLineTool' as 'runtime.tmpdirSize', must be a non-zero integer.\n",
-        "default": 1024
-      },
-      "ResourceTmpDirMaximum": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/ResourceQuantityOrFractional-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          }
-        ],
-        "title": "ResourceTmpDirMaximum",
-        "summary": "Maximum reserved filesystem based storage for the designated temporary directory in mebibytes.",
-        "description": "Maximum reserved filesystem based storage for the designated temporary directory in mebibytes (2**20).\nSee 'tmpdirMin' for discussion about fractional storage requests.\n"
-      },
-      "ResourceOutDirMinimum": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/ResourceQuantityOrFractional-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          }
-        ],
-        "title": "ResourceOutDirMinimum",
-        "summary": "Minimum reserved filesystem based storage for the designated output directory in mebibytes.",
-        "description": "Minimum reserved filesystem based storage for the designated output\ndirectory in mebibytes (2**20).\n\nMay be a fractional value. If so, the actual storage request must be rounded\nup to the next whole number.\n\nThe reported amount of storage reserved for the process, which is available\nto expressions on the 'CommandLineTool' as 'runtime.outdirSize', must be a non-zero integer.\n",
-        "default": 1024
-      },
-      "ResourceOutDirMaximum": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/ResourceQuantityOrFractional-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          }
-        ],
-        "title": "ResourceOutDirMaximum",
-        "summary": "Maximum reserved filesystem based storage for the designated output directory in mebibytes.",
-        "description": "Maximum reserved filesystem based storage for the designated output\ndirectory in mebibytes (2**20).\nSee 'outdirMin' for discussion about fractional storage requests.\n",
-        "default": 1
-      },
-      "ResourceRequirement-2": {
-        "type": "object",
-        "title": "ResourceRequirement",
-        "description": "Specify basic hardware resource requirements\n(see also: https://www.commonwl.org/v1.2/CommandLineTool.html#ResourceRequirement).\n",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "ResourceRequirement"
-            ]
-          },
-          "coresMin": {
-            "$ref": "#/components/schemas/ResourceCoresMinimum"
-          },
-          "coresMax": {
-            "$ref": "#/components/schemas/ResourceCoresMaximum"
-          },
-          "ramMin": {
-            "$ref": "#/components/schemas/ResourceRAMMinimum"
-          },
-          "ramMax": {
-            "$ref": "#/components/schemas/ResourceRAMMaximum"
-          },
-          "tmpdirMin": {
-            "$ref": "#/components/schemas/ResourceTmpDirMinimum"
-          },
-          "tmpdirMax": {
-            "$ref": "#/components/schemas/ResourceTmpDirMaximum"
-          },
-          "outdirMin": {
-            "$ref": "#/components/schemas/ResourceOutDirMinimum"
-          },
-          "outdirMax": {
-            "$ref": "#/components/schemas/ResourceOutDirMaximum"
-          }
-        },
-        "additionalProperties": false
-      },
-      "ScatterFeatureRequirement-2": {
-        "type": "object",
-        "title": "ScatterFeatureRequirement",
-        "description": "A 'scatter' operation specifies that the associated Workflow step should execute separately over a list of\ninput elements. Each job making up a scatter operation is independent and may be executed concurrently\n(see also: https://www.commonwl.org/v1.2/Workflow.html#WorkflowStep).\n",
-        "$comment": "Fields 'scatter' and 'scatterMethod' at the root of a 'WorkflowStep', not within the requirement.",
-        "properties": {
-          "class": {
-            "type": "string",
-            "description": "CWL requirement class specification.",
-            "enum": [
-              "ScatterFeatureRequirement"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "TimeLimitValue": {
-        "oneOf": [
-          {
-            "type": "number",
-            "minimum": 0
-          },
-          {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          }
-        ],
-        "title": "TimeLimitValue",
-        "description": "The time limit, in seconds.\n\nA time limit of zero means no time limit.\nNegative time limits are an error.\n"
-      },
-      "ToolTimeLimitRequirement-2": {
-        "type": "object",
-        "title": "ToolTimeLimitRequirement",
-        "description": "Set an upper limit on the execution time of a CommandLineTool.\n\nA CommandLineTool whose execution duration exceeds the time limit may be preemptively\nterminated and considered failed. May also be used by batch systems to make scheduling decisions.\n\nThe execution duration excludes external operations, such as staging of files,\npulling a docker image etc., and only counts wall-time for the execution of the command line itself.\n",
-        "properties": {
-          "class": {
-            "type": "string",
-            "$comment": "not 'ToolTimeLimitRequirement'",
-            "enum": [
-              "ToolTimeLimit"
-            ]
-          },
-          "timelimit": {
-            "$ref": "#/components/schemas/TimeLimitValue"
-          }
-        },
-        "required": [
-          "timelimit"
-        ],
-        "additionalProperties": false
-      },
-      "EnableReuseValue": {
-        "oneOf": [
-          {
-            "type": "boolean"
-          },
-          {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          }
-        ],
-        "title": "EnableReuseValue",
-        "description": "Indicates if reuse is enabled for this tool.\n\nCan be an expression when combined with 'InlineJavascriptRequirement'\n(see also: https://www.commonwl.org/v1.2/CommandLineTool.html#Expression).\n"
-      },
-      "WorkReuseRequirement-2": {
-        "type": "object",
-        "title": "WorkReuseRequirement",
-        "description": "For implementations that support reusing output from past work\n(on the assumption that same code and same input produce same results),\ncontrol whether to enable or disable the reuse behavior for a particular tool\nor step (to accommodate situations where that assumption is incorrect).\n\nA reused step is not executed but instead returns the same output as the original execution.\n\nIf 'WorkReuse' is not specified, correct tools should assume it is enabled by default.\n",
-        "properties": {
-          "class": {
-            "type": "string",
-            "$comment": "Not 'WorkReuseRequirement'.",
-            "enum": [
-              "WorkReuse"
-            ]
-          },
-          "enableReuse": {
-            "$ref": "#/components/schemas/EnableReuseValue"
-          }
-        },
-        "required": [
-          "enableReuse"
-        ],
-        "additionalProperties": false
-      },
-      "MultipleInputFeatureRequirement-2": {
-        "type": "object",
-        "title": "MultipleInputFeatureRequirement",
-        "description": "Indicates that the 'Workflow' must support multiple inbound data links listed in the 'source'\nfield of 'WorkflowStepInput'.\n",
-        "properties": {
-          "class": {
-            "type": "string",
-            "description": "CWL requirement class specification.",
-            "enum": [
-              "MultipleInputFeatureRequirement"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "StepInputExpressionRequirement-2": {
-        "type": "object",
-        "title": "StepInputExpressionRequirement",
-        "description": "Indicates that the 'Workflow' must support the 'valueFrom' field of 'WorkflowStepInput'.",
-        "properties": {
-          "class": {
-            "type": "string",
-            "description": "CWL requirement class specification.",
-            "enum": [
-              "StepInputExpressionRequirement"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "SubworkflowFeatureRequirement-2": {
-        "type": "object",
-        "title": "SubworkflowFeatureRequirement",
-        "description": "Indicates that the 'Workflow' must support nested workflows in the 'run' field of 'WorkflowStep'.",
-        "properties": {
-          "class": {
-            "type": "string",
-            "description": "CWL requirement class specification.",
-            "enum": [
-              "SubworkflowFeatureRequirement"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "CWLRequirementsMap-2": {
-        "title": "CWLRequirementsMap",
-        "type": "object",
-        "properties": {
-          "cwltool:CUDARequirement": {
-            "$ref": "#/components/schemas/cwltool:CUDARequirement"
-          },
-          "DockerRequirement": {
-            "$ref": "#/components/schemas/DockerRequirement-2"
-          },
-          "SoftwareRequirement": {
-            "$ref": "#/components/schemas/SoftwareRequirement-2"
-          },
-          "ShellCommandRequirement": {
-            "$ref": "#/components/schemas/ShellCommandRequirement-2"
-          },
-          "EnvVarRequirement": {
-            "$ref": "#/components/schemas/EnvVarRequirement-2"
-          },
-          "SchemaDefRequirement": {
-            "$ref": "#/components/schemas/SchemaDefRequirement-2"
-          },
-          "InitialWorkDirRequirement": {
-            "$ref": "#/components/schemas/InitialWorkDirRequirement-2"
-          },
-          "InlineJavascriptRequirement": {
-            "$ref": "#/components/schemas/InlineJavascriptRequirement-2"
-          },
-          "InplaceUpdateRequirement": {
-            "$ref": "#/components/schemas/InplaceUpdateRequirement-2"
-          },
-          "LoadListingRequirement": {
-            "$ref": "#/components/schemas/LoadListingRequirement-2"
-          },
-          "NetworkAccess": {
-            "$comment": "Not 'NetworkAccessRequirement'",
-            "$ref": "#/components/schemas/NetworkAccessRequirement-2"
-          },
-          "ResourceRequirement": {
-            "$ref": "#/components/schemas/ResourceRequirement-2"
-          },
-          "ScatterFeatureRequirement": {
-            "$ref": "#/components/schemas/ScatterFeatureRequirement-2"
-          },
-          "ToolTimeLimit": {
-            "$comment": "Not 'ToolTimeLimitRequirement'.",
-            "$ref": "#/components/schemas/ToolTimeLimitRequirement-2"
-          },
-          "WorkReuse": {
-            "$comment": "Not 'WorkReuseRequirement'.",
-            "$ref": "#/components/schemas/WorkReuseRequirement-2"
-          },
-          "MultipleInputFeatureRequirement": {
-            "$ref": "#/components/schemas/MultipleInputFeatureRequirement-2"
-          },
-          "StepInputExpressionRequirement": {
-            "$ref": "#/components/schemas/StepInputExpressionRequirement-2"
-          },
-          "SubworkflowFeatureRequirement": {
-            "$ref": "#/components/schemas/SubworkflowFeatureRequirement-2"
-          }
-        },
-        "additionalProperties": false
-      },
-      "CWLRequirementsItem-2": {
-        "title": "CWLRequirementsItem",
-        "$comment": "For any new items added, ensure they are added under 'class' of 'UnknownRequirement' as well.\nOtherwise, insufficiently restrictive classes could cause multiple matches, failing the 'oneOf' condition.\n",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/cwltool:CUDARequirement"
-          },
-          {
-            "$ref": "#/components/schemas/DockerRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/SoftwareRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/ShellCommandRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/EnvVarRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/SchemaDefRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/InitialWorkDirRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/InlineJavascriptRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/InplaceUpdateRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/LoadListingRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/NetworkAccessRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/ResourceRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/ScatterFeatureRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/ToolTimeLimitRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/WorkReuseRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/MultipleInputFeatureRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/StepInputExpressionRequirement-2"
-          },
-          {
-            "$ref": "#/components/schemas/SubworkflowFeatureRequirement-2"
-          }
-        ]
-      },
-      "CWLRequirementsList-2": {
-        "type": "array",
-        "title": "CWLRequirementsList",
-        "items": {
-          "oneOf": [
-            {
-              "allOf": [
-                {
-                  "$comment": "When using the list representation, 'class' is required to indicate which one is being represented.\nWhen using the mapping representation, 'class' is optional since it's the key, but it must match by name.\n",
-                  "required": [
-                    "class"
-                  ]
-                },
-                {
-                  "$ref": "#/components/schemas/CWLRequirementsItem-2"
-                }
-              ]
-            },
-            {
-              "$ref": "#/components/schemas/CWLImport-2"
-            }
-          ]
-        }
-      },
-      "CWLRequirements-2": {
-        "title": "CWLRequirements",
-        "description": "Explicit requirement to execute the application package.",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLRequirementsMap-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLRequirementsList-2"
-          }
-        ]
-      },
-      "BuiltinRequirement": {
-        "type": "object",
-        "title": "BuiltinRequirement",
-        "description": "Hint indicating that the Application Package corresponds to a\nbuiltin process of this instance. (note: can only be an 'hint'\nas it is unofficial CWL specification).\n",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "BuiltinRequirement"
-            ]
-          },
-          "process": {
-            "$comment": "Builtin process identifier.",
-            "$ref": "#/components/schemas/CWLTextPatternID"
-          }
-        },
-        "required": [
-          "process",
-          "class"
-        ],
-        "additionalProperties": false
-      },
-      "WPS1Requirement": {
-        "type": "object",
-        "title": "WPS1Requirement",
-        "description": "Hint indicating that the Application Package corresponds to a\nWPS-1 provider process that should be remotely executed and monitored by this\ninstance. (note: can only be an ''hint'' as it is unofficial CWL specification).\n",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "WPS1Requirement"
-            ]
-          },
-          "process": {
-            "$comment": "Process identifier of the remote WPS provider.",
-            "$ref": "#/components/schemas/CWLTextPatternID"
-          },
-          "provider": {
-            "description": "WPS provider endpoint.",
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          }
-        },
-        "required": [
-          "process",
-          "provider"
-        ],
-        "additionalProperties": false
-      },
-      "UnknownRequirement": {
-        "type": "object",
-        "description": "Generic schema to allow alternative CWL requirements/hints not explicitly defined in schemas.",
-        "properties": {
-          "class": {
-            "type": "string",
-            "title": "Requirement Class Identifier",
-            "description": "CWL requirement class specification.",
-            "example": "UnknownRequirement",
-            "not": {
-              "enum": [
-                "cwltool:CUDARequirement",
-                "DockerRequirement",
-                "SoftwareRequirement",
-                "ShellCommandRequirement",
-                "EnvVarRequirement",
-                "SchemaDefRequirement",
-                "InitialWorkDirRequirement",
-                "InlineJavascriptRequirement",
-                "InplaceUpdateRequirement",
-                "LoadListingRequirement",
-                "NetworkAccess",
-                "ResourceRequirement",
-                "ScatterFeatureRequirement",
-                "ToolTimeLimit",
-                "WorkReuse",
-                "MultipleInputFeatureRequirement",
-                "StepInputExpressionRequirement",
-                "SubworkflowFeatureRequirement"
-              ]
-            }
-          }
-        },
-        "additionalProperties": {}
-      },
-      "CWLHintsMapExtras": {
-        "type": "object",
-        "properties": {
-          "BuiltinRequirement": {
-            "$ref": "#/components/schemas/BuiltinRequirement"
-          },
-          "OGCAPIRequirement": {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          },
-          "WPS1Requirement": {
-            "$ref": "#/components/schemas/WPS1Requirement"
-          }
-        },
-        "additionalProperties": {
-          "$ref": "#/components/schemas/UnknownRequirement"
-        }
-      },
-      "CWLHintsMap-2": {
-        "title": "CWLHintsMap",
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/CWLRequirementsMap-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLHintsMapExtras"
-          }
-        ]
-      },
-      "CWLHintsItemExtras": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/BuiltinRequirement"
-          },
-          {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          },
-          {
-            "$ref": "#/components/schemas/WPS1Requirement"
-          },
-          {
-            "$ref": "#/components/schemas/UnknownRequirement"
-          }
-        ]
-      },
-      "CWLHintsItem": {
-        "title": "CWLHintsItem",
-        "$comment": "For any new items added, ensure they are added under 'class' of 'UnknownRequirement' as well.\nOtherwise, insufficiently restrictive classes could cause multiple matches, failing the 'oneOf' condition.\n",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLRequirementsItem-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLHintsItemExtras"
-          }
-        ]
-      },
-      "CWLHintsList-2": {
-        "type": "array",
-        "title": "CWLHintsList",
-        "items": {
-          "oneOf": [
-            {
-              "allOf": [
-                {
-                  "$comment": "When using the list representation, 'class' is required to indicate which one is being represented.\nWhen using the mapping representation, 'class' is optional since it's the key, but it must match by name.\n",
-                  "required": [
-                    "class"
-                  ]
-                },
-                {
-                  "$ref": "#/components/schemas/CWLHintsItem"
-                }
-              ]
-            },
-            {
-              "$ref": "#/components/schemas/CWLImport-2"
-            }
-          ]
-        }
-      },
-      "CWLHints-2": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLHintsMap-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLHintsList-2"
-          }
-        ],
-        "title": "CWLHints",
-        "description": "Non-failing additional hints that can help resolve extra requirements."
-      },
-      "CWLCommand-2": {
-        "oneOf": [
-          {
-            "type": "string",
-            "title": "String command."
-          },
-          {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          }
-        ],
-        "title": "CWLCommand",
-        "description": "Command called in the docker image or on shell according to requirements\nand hints specifications. Can be omitted if already defined in the docker\nimage.\n"
-      },
-      "InputBinding-2": {
-        "type": "object",
-        "title": "Input Binding",
-        "description": "Defines how to specify the input for the command.",
-        "properties": {
-          "prefix": {
-            "type": "string"
-          },
-          "position": {
-            "oneOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "$ref": "#/components/schemas/CWLExpression-2"
-              }
-            ]
-          },
-          "valueFrom": {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          },
-          "itemSeparator": {
-            "type": "string"
-          },
-          "shellQuote": {
-            "type": "boolean"
-          }
-        },
-        "additionalProperties": false
-      },
-      "CWLArguments-2": {
-        "type": "array",
-        "title": "CWLArguments",
-        "description": "Base arguments passed to the command.",
-        "items": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/components/schemas/InputBinding-2"
-            }
-          ]
-        }
-      },
-      "CWLInputStdInObjectType-2": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/CWLInputStdInDefinition-2"
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "CWLInputStdIn-2": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLInputStdInDefinition-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLInputStdInObjectType-2"
-          }
-        ]
-      },
-      "CWLInputItemBase": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/CWLType-2"
-              },
-              {
-                "$ref": "#/components/schemas/CWLInputStdIn-2"
-              }
-            ]
-          },
-          "inputBinding": {
-            "$ref": "#/components/schemas/InputBinding-2"
-          },
-          "id": {
-            "description": "Identifier of the CWL input.",
-            "$ref": "#/components/schemas/CWLIdentifier"
-          }
-        },
-        "required": [
-          "type",
-          "id"
-        ],
-        "additionalProperties": {}
-      },
-      "AnyType-2": {
-        "oneOf": [
-          {
-            "type": "boolean"
-          },
-          {
-            "type": "number"
-          },
-          {
-            "type": "string"
-          },
-          {
-            "type": "array",
-            "items": {}
-          },
-          {
-            "type": "object"
-          }
-        ]
-      },
-      "CWLDefaultTypedConditional-2": {
-        "$comment": "Validate that the 'default' value, if specified, is of same type as the CWL 'type'.\nThis avoids over-accepting anything that does not match the intended type.\nHowever, validation limits itself to data literals and arrays.\nNested type and multi-type definitions will validate against 'Any'.\n",
-        "allOf": [
-          {
-            "$comment": "Object structure with minimally 'type' and 'default'. Otherwise, no point to continue testing.",
-            "type": "object",
-            "properties": {
-              "type": {
-                "$ref": "#/components/schemas/AnyType-2"
-              },
-              "default": {
-                "$ref": "#/components/schemas/AnyType-2"
-              }
-            },
-            "required": [
-              "type"
-            ]
-          },
-          {
-            "$comment": "Explicit \"null\" string.",
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "null"
-                }
-              }
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "$ref": "#/$defs/NullableType"
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Required string.",
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "string"
-                }
-              }
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Optional string.",
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "string?"
-                }
-              }
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "oneOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "$ref": "#/$defs/NullableType"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Required boolean.",
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "boolean"
-                }
-              }
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "type": "boolean"
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Optional boolean.",
-            "if": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "double?",
-                    "float?",
-                    "int?",
-                    "integer?",
-                    "long?"
-                  ]
-                }
-              }
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "oneOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "$ref": "#/$defs/NullableType"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Required numeric.",
-            "if": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "double",
-                    "float",
-                    "int",
-                    "integer",
-                    "long"
-                  ]
-                }
-              }
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "type": "number"
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Optional numeric.",
-            "if": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "double?",
-                    "float?",
-                    "int?",
-                    "integer?",
-                    "long?"
-                  ]
-                }
-              }
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "oneOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "$ref": "#/$defs/NullableType"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Required enum.",
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "enum"
-                },
-                "symbols": {
-                  "$ref": "#/$defs/CWLTypeSymbols"
-                }
-              }
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "type": {
-                    "$ref": "#/$defs/CWLTypeSymbolValues"
-                  }
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Optional enum.",
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "enum?"
-                },
-                "symbols": {
-                  "$ref": "#/$defs/CWLTypeSymbols"
-                }
-              }
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/$defs/CWLTypeSymbolValues"
-                    },
-                    {
-                      "$ref": "#/$defs/NullableType"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Required File or Directory.",
-            "if": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "Directory",
-                    "File"
-                  ]
-                }
-              }
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "$ref": "#/$defs/CWLDefaultLocation"
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Optional File or Directory.",
-            "if": {
-              "properties": {
-                "type": {
-                  "enum": [
-                    "Directory?",
-                    "File?"
-                  ]
-                }
-              }
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/$defs/CWLDefaultLocation"
-                    },
-                    {
-                      "$ref": "#/$defs/NullableType"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Required array of string.",
-            "if": {
-              "oneOf": [
-                {
-                  "properties": {
-                    "type": {
-                      "const": "string[]"
-                    }
-                  }
-                },
-                {
-                  "properties": {
-                    "type": {
-                      "const": "array"
-                    },
-                    "items": {
-                      "const": "string"
-                    }
-                  }
-                }
-              ]
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Required array of boolean.",
-            "if": {
-              "oneOf": [
-                {
-                  "properties": {
-                    "type": {
-                      "const": "boolean[]"
-                    }
-                  }
-                },
-                {
-                  "properties": {
-                    "type": {
-                      "const": "array"
-                    },
-                    "items": {
-                      "const": "boolean"
-                    }
-                  }
-                }
-              ]
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "type": "array",
-                  "items": {
-                    "type": "boolean"
-                  }
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Required array of numeric.",
-            "if": {
-              "oneOf": [
-                {
-                  "properties": {
-                    "type": {
-                      "enum": [
-                        "double[]",
-                        "float[]",
-                        "int[]",
-                        "integer[]",
-                        "long[]"
-                      ]
-                    }
-                  }
-                },
-                {
-                  "properties": {
-                    "type": {
-                      "const": "array"
-                    },
-                    "items": {
-                      "enum": [
-                        "double",
-                        "float",
-                        "int",
-                        "integer",
-                        "long"
-                      ]
-                    }
-                  }
-                }
-              ]
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "type": "array",
-                  "items": {
-                    "type": "number"
-                  }
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Required anything (single).",
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "Any"
-                }
-              }
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "$comment": "Match anything.",
-                  "$ref": "#/$defs/AnyType"
-                }
-              }
-            }
-          },
-          {
-            "$comment": "Required array of anything.",
-            "if": {
-              "properties": {
-                "type": {
-                  "const": "Any[]"
-                }
-              }
-            },
-            "then": {
-              "properties": {
-                "default": {
-                  "$comment": "Match anything as long as under array.",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/$defs/AnyType"
-                  }
-                }
-              }
-            }
-          }
-        ]
-      },
-      "CWLInputItem-2": {
-        "title": "Input",
-        "description": "Input specification. Note that multiple formats are supported and\nnot all specification variants or parameters are presented here. Please refer\nto official CWL documentation for more details (https://www.commonwl.org).\n",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLInputItemBase"
-          },
-          {
-            "$ref": "#/components/schemas/CWLDefaultTypedConditional-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLDocumentation-2"
-          }
-        ]
-      },
-      "CWLInputList-2": {
-        "type": "array",
-        "title": "CWLInputList",
-        "description": "Package inputs defined as items.",
-        "items": {
-          "$ref": "#/components/schemas/CWLInputItem-2"
-        }
-      },
-      "CWLInputObjectBase": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/CWLType-2"
-          },
-          "inputBinding": {
-            "$ref": "#/components/schemas/InputBinding-2",
-            "additionalProperties": {}
-          }
-        },
-        "required": [
-          "type"
-        ],
-        "additionalProperties": {}
-      },
-      "CWLInputObject": {
-        "title": "CWLInputObject",
-        "summary": "CWL type definition with parameters.",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLInputObjectBase"
-          },
-          {
-            "$ref": "#/components/schemas/CWLDefaultTypedConditional-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLDocumentation-2"
-          }
-        ]
-      },
-      "CWLInputMap-2": {
-        "type": "object",
-        "title": "CWLInputMap",
-        "description": "Package inputs defined as mapping.",
-        "properties": {},
-        "required": [],
-        "additionalProperties": {
-          "oneOf": [
-            {
-              "$ref": "#/components/schemas/CWLType-2"
-            },
-            {
-              "$ref": "#/components/schemas/CWLInputObject"
-            },
-            {
-              "$ref": "#/components/schemas/CWLInputStdIn-2"
-            },
-            {
-              "$ref": "#/components/schemas/CWLImport-2"
-            }
-          ]
-        }
-      },
-      "CWLInputsDefinition-2": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLInputList-2"
-          },
-          {
-            "$comment": "Avoid 'oneOf' conflict of generic mapping key strings as input identifier matching against '$import'.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/CWLInputMap-2"
-              },
-              {
-                "not": {
-                  "$ref": "#/components/schemas/CWLImport-2"
-                }
-              }
-            ]
-          },
-          {
-            "$ref": "#/components/schemas/CWLImport-2"
-          }
-        ],
-        "title": "CWLInputsDefinition",
-        "description": "All inputs available to the Application Package."
-      },
-      "CWLOutputStdOutObjectType-2": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/CWLOutputStdOutDefinition-2"
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "CWLOutputStdOut-2": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLOutputStdOutDefinition-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLOutputStdOutObjectType-2"
-          }
-        ]
-      },
-      "CWLOutputStdErrObjectType-2": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/CWLOutputStdErrDefinition-2"
-          }
-        },
-        "required": [
-          "type"
-        ]
-      },
-      "CWLOutputStdErr-2": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLOutputStdErrDefinition-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLOutputStdErrObjectType-2"
-          }
-        ]
-      },
-      "OutputBinding": {
-        "type": "object",
-        "title": "OutputBinding",
-        "description": "Defines how to retrieve the output result from the command.",
-        "properties": {
-          "glob": {
-            "description": "Glob pattern to find the output on disk or mounted docker volume.",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/CWLExpression-2"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/CWLExpression-2"
-                }
-              }
-            ]
-          }
-        },
-        "additionalProperties": {}
-      },
-      "CWLOutputItem-2": {
-        "type": "object",
-        "title": "CWLOutputItem",
-        "description": "Output specification. Note that multiple formats are supported\nand not all specification variants or parameters are presented here. Please\nrefer to official CWL documentation for more details (https://www.commonwl.org).\n",
-        "properties": {
-          "type": {
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/CWLType-2"
-              },
-              {
-                "$ref": "#/components/schemas/CWLOutputStdOut-2"
-              },
-              {
-                "$ref": "#/components/schemas/CWLOutputStdErr-2"
-              }
-            ]
-          },
-          "outputBinding": {
-            "$ref": "#/components/schemas/OutputBinding"
-          },
-          "id": {
-            "description": "Identifier of the CWL output.",
-            "$ref": "#/components/schemas/CWLIdentifier"
-          }
-        },
-        "required": [
-          "type",
-          "id"
-        ],
-        "additionalProperties": {}
-      },
-      "CWLOutputList-2": {
-        "type": "array",
-        "title": "CWLOutputList",
-        "description": "Package outputs defined as items.",
-        "items": {
-          "$ref": "#/components/schemas/CWLOutputItem-2"
-        }
-      },
-      "CWLOutputObjectBase": {
-        "type": "object",
-        "title": "CWLOutputObject",
-        "summary": "CWL type definition with parameters.",
-        "properties": {
-          "type": {
-            "$ref": "#/components/schemas/CWLType-2"
-          },
-          "outputBinding": {
-            "$ref": "#/components/schemas/OutputBinding"
-          }
-        },
-        "required": [
-          "type"
-        ],
-        "additionalProperties": {}
-      },
-      "CWLOutputObject-2": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLDocumentation-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLOutputObjectBase"
-          }
-        ]
-      },
-      "CWLOutputMap-2": {
-        "type": "object",
-        "title": "CWLOutputMap",
-        "description": "Package outputs defined as mapping.",
-        "properties": {},
-        "required": [],
-        "additionalProperties": {
-          "oneOf": [
-            {
-              "$ref": "#/components/schemas/CWLType-2"
-            },
-            {
-              "$ref": "#/components/schemas/CWLOutputObject-2"
-            },
-            {
-              "$ref": "#/components/schemas/CWLOutputStdOut-2"
-            },
-            {
-              "$ref": "#/components/schemas/CWLOutputStdErr-2"
-            },
-            {
-              "$ref": "#/components/schemas/CWLImport-2"
-            }
-          ]
-        }
-      },
-      "CWLOutputsDefinition-2": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLOutputList-2"
-          },
-          {
-            "$comment": "Avoid 'oneOf' conflict of generic mapping key strings as output identifier matching against '$import'.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/CWLOutputMap-2"
-              },
-              {
-                "not": {
-                  "$ref": "#/components/schemas/CWLImport-2"
-                }
-              }
-            ]
-          },
-          {
-            "$ref": "#/components/schemas/CWLImport-2"
-          }
-        ],
-        "title": "CWLOutputsDefinition",
-        "description": "All outputs produced by the Application Package."
-      },
-      "CWLScatterMulti": {
-        "type": "array",
-        "title": "CWLScatterMulti",
-        "items": {
-          "$ref": "#/components/schemas/CWLIdentifier"
-        }
-      },
-      "CWLScatter": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLIdentifier"
-          },
-          {
-            "$ref": "#/components/schemas/CWLScatterMulti"
-          }
-        ],
-        "title": "CWLScatter",
-        "description": "One or more input identifier of an application step within a Workflow\nwere an array-based input to that Workflow should be scattered across multiple\ninstances of the step application.\n"
-      },
-      "CWLAtomicBase-2": {
-        "type": "object",
-        "title": "CWL atomic definition",
-        "description": "Direct CWL definition instead of the graph representation.",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/CWLIdentifier"
-          },
-          "class": {
-            "type": "string",
-            "title": "Class",
-            "description": "CWL class specification. This is used to differentiate between single Application Package (AP)definitions and Workflow that chains multiple packages.",
-            "enum": [
-              "CommandLineTool",
-              "ExpressionTool"
-            ]
-          },
-          "intent": {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          },
-          "requirements": {
-            "$ref": "#/components/schemas/CWLRequirements-2"
-          },
-          "hints": {
-            "$ref": "#/components/schemas/CWLHints-2"
-          },
-          "baseCommand": {
-            "$ref": "#/components/schemas/CWLCommand-2"
-          },
-          "arguments": {
-            "$ref": "#/components/schemas/CWLArguments-2"
-          },
-          "inputs": {
-            "$ref": "#/components/schemas/CWLInputsDefinition-2"
-          },
-          "outputs": {
-            "$ref": "#/components/schemas/CWLOutputsDefinition-2"
-          },
-          "stdin": {
-            "description": "Source of the input stream.\nTypically, an expression referring to an existing file name or an input of the CWL document.\n",
-            "$ref": "#/components/schemas/CWLExpression-2"
-          },
-          "stdout": {
-            "description": "Destination of the output stream.\nTypically, an expression referring to a desired file name or provided by a CWL input reference.\n",
-            "$ref": "#/components/schemas/CWLExpression-2"
-          },
-          "stderr": {
-            "description": "Destination of the error stream.\nTypically, an expression referring to a desired file name or provided by a CWL input reference.\n",
-            "$ref": "#/components/schemas/CWLExpression-2"
-          },
-          "scatter": {
-            "$ref": "#/components/schemas/CWLScatter"
-          },
-          "scatterMethod": {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          }
-        },
-        "required": [
-          "class",
-          "inputs",
-          "outputs"
-        ]
-      },
-      "CWLAtomic-2": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLVersion-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLMetadata-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLDocumentation-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLAtomicBase-2"
-          }
-        ]
-      },
-      "CWLGraphItemBase": {
-        "type": "object",
-        "title": "CWLGraphItem",
-        "properties": {
-          "class": {
-            "type": "string",
-            "title": "Class",
-            "description": "CWL class specification. This is used to differentiate between single Application Package (AP)definitions and Workflow that chains multiple packages.",
-            "enum": [
-              "CommandLineTool",
-              "ExpressionTool",
-              "Workflow"
-            ]
-          },
-          "id": {
-            "$ref": "#/components/schemas/CWLIdentifier"
-          },
-          "intent": {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          },
-          "requirements": {
-            "$ref": "#/components/schemas/CWLRequirements-2"
-          },
-          "hints": {
-            "$ref": "#/components/schemas/CWLHints-2"
-          },
-          "baseCommand": {
-            "$ref": "#/components/schemas/CWLCommand-2"
-          },
-          "arguments": {
-            "$ref": "#/components/schemas/CWLArguments-2"
-          },
-          "inputs": {
-            "$ref": "#/components/schemas/CWLInputsDefinition-2"
-          },
-          "outputs": {
-            "$ref": "#/components/schemas/CWLOutputsDefinition-2"
-          },
-          "scatter": {
-            "$ref": "#/components/schemas/CWLScatter"
-          },
-          "scatterMethod": {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          }
-        },
-        "required": [
-          "class",
-          "id",
-          "inputs",
-          "outputs"
-        ],
-        "additionalProperties": {}
-      },
-      "CWLGraphItem": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLMetadata-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLDocumentation-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLGraphItemBase"
-          }
-        ]
-      },
-      "CWLGraphList": {
-        "type": "array",
-        "title": "CWLGraphList",
-        "description": "Graph definition that defines *exactly one* CWL application package represented as list. Multiple definitions simultaneously deployed is NOT supported currently.",
-        "items": {
-          "$ref": "#/components/schemas/CWLGraphItem"
-        },
-        "maxItems": 1,
-        "minItems": 1
-      },
-      "CWLGraphBase": {
-        "type": "object",
-        "properties": {
-          "$graph": {
-            "$ref": "#/components/schemas/CWLGraphList"
-          }
-        },
-        "required": [
-          "$graph"
-        ],
-        "additionalProperties": {}
-      },
-      "CWLGraph-2": {
-        "title": "CWLGraph",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLVersion-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLMetadata-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLDocumentation-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLGraphBase"
-          }
-        ]
-      },
-      "CWLWorkflowClass-2": {
-        "type": "object",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "Workflow"
-            ]
-          }
-        }
-      },
-      "CWLWorkflowStepInputBase-2": {
-        "type": "object",
-        "properties": {
-          "source": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            ]
-          },
-          "linkMerge": {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          },
-          "valueFrom": {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          }
-        }
-      },
-      "AnyLiteralType-2": {
-        "oneOf": [
-          {
-            "type": "number"
-          },
-          {
-            "type": "boolean"
-          },
-          {
-            "type": "string"
-          }
-        ]
-      },
-      "AnyLiteralList-2": {
-        "type": "array",
-        "title": "AnyLiteralList",
-        "items": {
-          "$ref": "#/components/schemas/AnyLiteralType-2"
-        }
-      },
-      "CWLDefaultLocation-2": {
-        "type": "object",
-        "properties": {
-          "class": {
-            "type": "string",
-            "enum": [
-              "File",
-              "Directory"
-            ]
-          },
-          "path": {
-            "type": "string"
-          },
-          "location": {
-            "type": "string"
-          },
-          "basename": {
-            "type": "string"
-          },
-          "nameroot": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "class"
-        ],
-        "oneOf": [
-          {
-            "required": [
-              "path"
-            ]
-          },
-          {
-            "required": [
-              "location"
-            ]
-          }
-        ],
-        "additionalProperties": false
-      },
-      "CWLDefaultObject-2": {
-        "type": "object",
-        "not": {
-          "$comment": "Avoid false-positive match of default File or Directory location definition.",
-          "properties": {
-            "class": {
-              "type": "string",
-              "enum": [
-                "File",
-                "Directory"
-              ]
-            }
-          }
-        },
-        "additionalProperties": {}
-      },
-      "CWLDefault-2": {
-        "title": "CWLDefault",
-        "description": "Default value of input if not provided for task execution.",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/AnyLiteralType-2"
-          },
-          {
-            "$ref": "#/components/schemas/AnyLiteralList-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLDefaultLocation-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLDefaultObject-2"
-          },
-          {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CWLDefaultObject-2"
-            }
-          }
-        ]
-      },
-      "CWLWorkflowStepInputDefault-2": {
-        "$comment": "CWL 'type' is not specified at this level for step inputs\n(it is provided by the mapped input of the nested tool instead).\nTherefore, cannot validate against 'CWLDefaultTypedConditional'.\n",
-        "type": "object",
-        "properties": {
-          "default": {
-            "$ref": "#/components/schemas/CWLDefault-2"
-          }
-        }
-      },
-      "CWLWorkflowStepInput": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLWorkflowStepInputBase-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLWorkflowStepInputDefault-2"
-          }
-        ]
-      },
-      "CWLWorkflowStepInMap-2": {
-        "type": "object",
-        "additionalProperties": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            {
-              "$ref": "#/components/schemas/CWLWorkflowStepInput"
-            }
-          ]
-        }
-      },
-      "CWLWorkflowStepInputId-2": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/CWLIdentifier"
-          }
-        },
-        "required": [
-          "id"
-        ]
-      },
-      "CWLWorkflowStepInItem-2": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLWorkflowStepInputId-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLWorkflowStepInputBase-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLWorkflowStepInputDefault-2"
-          }
-        ]
-      },
-      "CWLWorkflowStepInList-2": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/CWLWorkflowStepInItem-2"
-        }
-      },
-      "CWLWorkflowStepIn-2": {
-        "description": "Mapping of Workflow step inputs to nested CWL tool definitions inputs or outputs.",
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLWorkflowStepInMap-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLWorkflowStepInList-2"
-          }
-        ]
-      },
-      "CWLAtomicNested-2": {
-        "$comment": "Same as 'CWLAtomic', but 'cwlVersion' not repeated (only at root).",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLMetadata-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLDocumentation-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLAtomicBase-2"
-          }
-        ]
-      },
-      "CWLWorkflowBase-2": {
-        "type": "object",
-        "properties": {
-          "steps": {
-            "$ref": "#/components/schemas/CWLWorkflowSteps-2"
-          },
-          "inputs": {
-            "$ref": "#/components/schemas/CWLInputsDefinition-2"
-          },
-          "outputs": {
-            "$ref": "#/components/schemas/CWLOutputsDefinition-2"
-          },
-          "requirements": {
-            "$comment": "Technically a different subset, but lots of redefinitions to be done.",
-            "$ref": "#/components/schemas/CWLRequirements-2"
-          },
-          "hints": {
-            "$comment": "Technically a different subset, but lots of redefinitions to be done.",
-            "$ref": "#/components/schemas/CWLHints-2"
-          }
-        }
-      },
-      "CWLWorkflowNested": {
-        "$comment": "Same as 'CWLWorkflow', but 'cwlVersion' not repeated (only at root).",
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLMetadata-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLDocumentation-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLWorkflowClass-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLWorkflowBase-2"
-          }
-        ]
-      },
-      "CWLWorkflowStepRun-2": {
-        "description": "Nested CWL definition to run as Workflow step.",
-        "oneOf": [
-          {
-            "description": "File or URL reference to a CWL tool definition.",
-            "type": "string"
-          },
-          {
-            "description": "Nested CWL tool definition for the step.",
-            "$ref": "#/components/schemas/CWLAtomicNested-2"
-          },
-          {
-            "description": "Nested CWL Workflow definition for the step.",
-            "$ref": "#/components/schemas/CWLWorkflowNested"
-          }
-        ]
-      },
-      "CWLWorkflowStepOutId": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/CWLIdentifier"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "additionalProperties": false
-      },
-      "CWLWorkflowStepOut-2": {
-        "description": "Mapping of Workflow step inputs to nested CWL tool definitions inputs or outputs.",
-        "type": "array",
-        "items": {
-          "oneOf": [
-            {
-              "$ref": "#/components/schemas/CWLIdentifier"
-            },
-            {
-              "$ref": "#/components/schemas/CWLWorkflowStepOutId"
-            }
-          ]
-        }
-      },
-      "CWLWorkflowStepDefinition-2": {
-        "type": "object",
-        "properties": {
-          "in": {
-            "$ref": "#/components/schemas/CWLWorkflowStepIn-2"
-          },
-          "run": {
-            "$ref": "#/components/schemas/CWLWorkflowStepRun-2"
-          },
-          "when": {
-            "$ref": "#/components/schemas/CWLExpression-2"
-          },
-          "out": {
-            "$ref": "#/components/schemas/CWLWorkflowStepOut-2"
-          }
-        },
-        "required": [
-          "in",
-          "run",
-          "out"
-        ]
-      },
-      "IdentifierArray": {
-        "type": "array",
-        "title": "IdentifierArray",
-        "items": {
-          "$ref": "#/components/schemas/CWLTextPatternID"
-        },
-        "minItems": 1
-      },
-      "Scatter": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLTextPatternID"
-          },
-          {
-            "$ref": "#/components/schemas/IdentifierArray"
-          }
-        ],
-        "title": "Scatter",
-        "description": "The scatter field specifies one or more input parameters which will be scattered.\n\nAn input parameter may be listed more than once. The declared type of each\ninput parameter implicitly becomes an array of items of the input parameter type.\nIf a parameter is listed more than once, it becomes a nested array. As a result,\nupstream parameters which are connected to scattered parameters must be arrays.\n\nAll output parameter types are also implicitly wrapped in arrays. Each job\nin the scatter results in an entry in the output array.\n\nIf any scattered parameter runtime value is an empty array, all outputs are\nset to empty arrays and no work is done for the step, according to applicable scattering rules.\n"
-      },
-      "CWLWorkflowStepScatter-2": {
-        "type": "object",
-        "properties": {
-          "scatter": {
-            "$ref": "#/components/schemas/Scatter"
-          },
-          "scatterMethod": {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
-          }
-        }
-      },
-      "CWLWorkflowStepObject-2": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLWorkflowStepDefinition-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLWorkflowStepScatter-2"
-          }
-        ]
-      },
-      "CWLWorkflowStepMap-2": {
-        "type": "object",
-        "additionalProperties": {
-          "$ref": "#/components/schemas/CWLWorkflowStepObject-2"
-        }
-      },
-      "CWLWorkflowStepId-2": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "$ref": "#/components/schemas/CWLIdentifier"
-          }
-        },
-        "required": [
-          "id"
-        ]
-      },
-      "CWLWorkflowStepItem": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLWorkflowStepId-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLWorkflowStepObject-2"
-          }
-        ]
-      },
-      "CWLWorkflowStepList-2": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/CWLWorkflowStepItem"
-        }
-      },
-      "CWLWorkflowSteps-2": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLWorkflowStepMap-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLWorkflowStepList-2"
-          }
-        ]
-      },
-      "CWLWorkflow-2": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CWLVersion-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLMetadata-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLDocumentation-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLWorkflowClass-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLWorkflowBase-2"
-          }
-        ]
-      },
-      "CWL-2": {
-        "oneOf": [
-          {
-            "$ref": "#/components/schemas/CWLAtomic-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLGraph-2"
-          },
-          {
-            "$ref": "#/components/schemas/CWLWorkflow-2"
-          }
-        ]
       },
       "schema-2": "{\r\n    \"id\": \"http://provenance.ecs.soton.ac.uk/prov-json/schema#\",\r\n    \"$schema\": \"http://json-schema.org/draft-04/schema#\",\r\n    \"description\": \"Schema for a PROV-JSON document\",\r\n    \"type\": \"object\",\r\n    \"additionalProperties\": false,\r\n    \"properties\": {\r\n        \"prefix\": {\r\n            \"type\": \"object\",\r\n            \"patternProperties\": {\r\n                        \"^[a-zA-Z0-9_\\\\-]+$\": { \"type\" : \"string\", \"format\": \"uri\" }\r\n            }\r\n        },\r\n        \"entity\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/entity\" }\r\n        },\r\n        \"activity\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/activity\" }\r\n        },\r\n        \"agent\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/agent\" }\r\n        },\r\n        \"wasGeneratedBy\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/generation\" }\r\n        },\r\n        \"used\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/usage\" }\r\n        },\r\n        \"wasInformedBy\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/communication\" }\r\n        },\r\n        \"wasStartedBy\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/start\" }\r\n        },\r\n        \"wasEndedby\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/end\" }\r\n        },\r\n        \"wasInvalidatedBy\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/invalidation\" }\r\n        },\r\n        \"wasDerivedFrom\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/derivation\" }\r\n        },\r\n        \"wasAttributedTo\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/attribution\" }\r\n        },\r\n        \"wasAssociatedWith\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/association\" }\r\n        },\r\n        \"actedOnBehalfOf\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/delegation\" }\r\n        },\r\n        \"wasInfluencedBy\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/influence\" }\r\n        },\r\n        \"specializationOf\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/specialization\" }\r\n        },\r\n        \"alternateOf\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/alternate\" }\r\n        },\r\n        \"hadMember\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/membership\" }\r\n        },\r\n        \"bundle\": {\r\n            \"type\": \"object\",\r\n            \"additionalProperties\": { \"$ref\":\"#/definitions/bundle\" }\r\n        }\r\n    },\r\n    \"definitions\": {\r\n        \"typedLiteral\": {\r\n            \"title\": \"PROV-JSON Typed Literal\",\r\n            \"type\": \"object\",\r\n            \"properties\": {\r\n                \"$\": { \"type\": \"string\" },\r\n                \"type\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"lang\": { \"type\": \"string\" }\r\n            },\r\n            \"required\": [\"$\"],\r\n            \"additionalProperties\": false\r\n        },\r\n        \"stringLiteral\": {\"type\": \"string\"},\r\n        \"numberLiteral\": {\"type\": \"number\"},\r\n        \"booleanLiteral\": {\"type\": \"boolean\"},\r\n        \"literalArray\": {\r\n            \"type\": \"array\",\r\n            \"minItems\": 1,\r\n            \"items\": {\r\n                \"anyOf\": [\r\n                    { \"$ref\": \"#/definitions/stringLiteral\" },\r\n                    { \"$ref\": \"#/definitions/numberLiteral\" },\r\n                    { \"$ref\": \"#/definitions/booleanLiteral\" },\r\n                    { \"$ref\": \"#/definitions/typedLiteral\" }\r\n                ]\r\n            }\r\n        },\r\n        \"attributeValues\": {\r\n            \"anyOf\": [\r\n                { \"$ref\": \"#/definitions/stringLiteral\" },\r\n                { \"$ref\": \"#/definitions/numberLiteral\" },\r\n                { \"$ref\": \"#/definitions/booleanLiteral\" },\r\n                { \"$ref\": \"#/definitions/typedLiteral\" },\r\n                { \"$ref\": \"#/definitions/literalArray\" }\r\n            ]\r\n        },\r\n        \"entity\": {\r\n            \"type\": \"object\",\r\n            \"title\": \"entity\",\r\n            \"additionalProperties\": { \"$ref\": \"#/definitions/attributeValues\" }\r\n        },\r\n        \"agent\": { \"$ref\": \"#/definitions/entity\" },\r\n        \"activity\": {\r\n            \"type\": \"object\",\r\n            \"title\": \"activity\",\r\n            \"prov:startTime\": { \"type\": \"string\", \"format\": \"date-time\" },\r\n            \"prov:endTime\": { \"type\": \"string\", \"format\": \"date-time\" },\r\n            \"additionalProperties\": { \"$ref\": \"#/definitions/attributeValues\" }\r\n        },\r\n        \"generation\": {\r\n            \"type\": \"object\",\r\n            \"title\": \"generation/usage\",\r\n            \"properties\": {\r\n                \"prov:entity\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:activity\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:time\": { \"type\": \"string\", \"format\": \"date-time\" }\r\n            },\r\n            \"required\": [\"prov:entity\"],\r\n            \"additionalProperties\": { \"$ref\": \"#/definitions/attributeValues\" }\r\n        },\r\n        \"usage\": {\"$ref\":\"#/definitions/generation\"},\r\n        \"communication\":{\r\n            \"type\": \"object\",\r\n            \"title\": \"communication\",\r\n            \"properties\": {\r\n                \"prov:informant\": {\"type\": \"string\", \"format\": \"uri\"},\r\n                \"prov:informed\": {\"type\": \"string\", \"format\": \"uri\"}\r\n            },\r\n            \"required\": [\"prov:informant\", \"prov:informed\"],\r\n            \"additionalProperties\": { \"$ref\": \"#/definitions/attributeValues\" }\r\n        },\r\n        \"start\":{\r\n            \"type\": \"object\",\r\n            \"title\": \"start/end\",\r\n            \"properties\": {\r\n                \"prov:activity\": {\"type\": \"string\", \"format\": \"uri\"},\r\n                \"prov:time\": {\"type\": \"string\", \"format\": \"date-time\"},\r\n                \"prov:trigger\": {\"type\": \"string\", \"format\": \"uri\"}\r\n            },\r\n            \"required\": [\"prov:activity\"],\r\n            \"additionalProperties\": { \"$ref\": \"#/definitions/attributeValues\" }\r\n        },\r\n        \"end\": {\"$ref\":\"#/definitions/start\"},\r\n        \"invalidation\":{\r\n            \"type\": \"object\",\r\n            \"title\": \"invalidation\",\r\n            \"properties\": {\r\n                \"prov:entity\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:time\": { \"type\": \"string\", \"format\": \"date-time\" },\r\n                \"prov:activity\": { \"type\": \"string\", \"format\": \"uri\" }\r\n            },\r\n            \"required\": [\"prov:entity\"],\r\n            \"additionalProperties\": { \"$ref\": \"#/definitions/attributeValues\" }\r\n        },\r\n        \"derivation\":{\r\n            \"type\": \"object\",\r\n            \"title\": \"derivation\",\r\n            \"properties\": {\r\n                \"prov:generatedEntity\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:usedEntity\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:activity\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:generation\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:usage\": { \"type\": \"string\", \"format\": \"uri\" }\r\n            },\r\n            \"required\": [\"prov:generatedEntity\", \"prov:usedEntity\"],\r\n            \"additionalProperties\": { \"$ref\": \"#/definitions/attributeValues\" }\r\n        },\r\n        \"attribution\":{\r\n            \"type\": \"object\",\r\n            \"title\": \"attribution\",\r\n            \"properties\": {\r\n                \"prov:entity\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:agent\": { \"type\": \"string\", \"format\": \"uri\" }\r\n            },\r\n            \"required\": [\"prov:entity\", \"prov:agent\"],\r\n            \"additionalProperties\": { \"$ref\": \"#/definitions/attributeValues\" }\r\n        },\r\n        \"association\": {\r\n            \"type\": \"object\",\r\n            \"title\": \"association\",\r\n            \"properties\": {\r\n                \"prov:activity\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:agent\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:plan\": { \"type\": \"string\", \"format\": \"uri\" }\r\n            },\r\n            \"required\": [\"prov:activity\"],\r\n            \"additionalProperties\": { \"$ref\": \"#/definitions/attributeValues\" }\r\n        },\r\n        \"delegation\": {\r\n            \"type\": \"object\",\r\n            \"title\": \"delegation\",\r\n            \"properties\": {\r\n                \"prov:delegate\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:responsible\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:activity\": { \"type\": \"string\", \"format\": \"uri\" }\r\n            },\r\n            \"required\": [\"prov:delegate\", \"prov:responsible\"],\r\n            \"additionalProperties\": { \"$ref\": \"#/definitions/attributeValues\" }\r\n        },\r\n        \"influence\": {\r\n            \"type\": \"object\",\r\n            \"title\": \"\",\r\n            \"properties\": {\r\n                \"prov:influencer\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:influencee\": { \"type\": \"string\", \"format\": \"uri\" }\r\n            },\r\n            \"required\": [\"prov:influencer\", \"prov:influencee\"],\r\n            \"additionalProperties\": { \"$ref\": \"#/definitions/attributeValues\" }\r\n        },\r\n        \"specialization\": {\r\n            \"type\": \"object\",\r\n            \"title\": \"specialization\",\r\n            \"properties\": {\r\n                \"prov:generalEntity\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:specificEntity\": { \"type\": \"string\", \"format\": \"uri\" }\r\n            },\r\n            \"required\": [\"prov:generalEntity\", \"prov:specificEntity\"],\r\n            \"additionalProperties\": { \"$ref\": \"#/definitions/attributeValues\" }\r\n        },\r\n        \"alternate\": {\r\n            \"type\": \"object\",\r\n            \"title\": \"alternate\",\r\n            \"properties\": {\r\n                \"prov:alternate1\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:alternate2\": { \"type\": \"string\", \"format\": \"uri\" }\r\n            },\r\n            \"required\": [\"prov:alternate1\", \"prov:alternate2\"],\r\n            \"additionalProperties\": { \"$ref\": \"#/definitions/attributeValues\" }\r\n        },\r\n        \"membership\": {\r\n            \"type\": \"object\",\r\n            \"title\": \"membership\",\r\n            \"properties\": {\r\n                \"prov:collection\": { \"type\": \"string\", \"format\": \"uri\" },\r\n                \"prov:entity\": { \"type\": \"string\", \"format\": \"uri\" }\r\n            },\r\n            \"required\": [\"prov:collection\", \"prov:entity\"],\r\n            \"additionalProperties\": { \"$ref\": \"#/definitions/attributeValues\" }\r\n        },\r\n        \"bundle\": {\r\n            \"type\": \"object\",\r\n            \"title\": \"bundle\",\r\n            \"properties\":{\r\n                \"prefix\": {\r\n                    \"type\": \"object\",\r\n                    \"patternProperties\": {\r\n                        \"^[a-zA-Z0-9_\\\\-]+$\": { \"type\" : \"string\", \"format\": \"uri\" }\r\n                    }\r\n                },\r\n                \"entity\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/entity\" }\r\n                },\r\n                \"activity\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/activity\" }\r\n                },\r\n                \"agent\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/agent\" }\r\n                },\r\n                \"wasGeneratedBy\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/generation\" }\r\n                },\r\n                \"used\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/usage\" }\r\n                },\r\n                \"wasInformedBy\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/communication\" }\r\n                },\r\n                \"wasStartedBy\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/start\" }\r\n                },\r\n                \"wasEndedby\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/end\" }\r\n                },\r\n                \"wasInvalidatedBy\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/invalidation\" }\r\n                },\r\n                \"wasDerivedFrom\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/derivation\" }\r\n                },\r\n                \"wasAttributedTo\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/attribution\" }\r\n                },\r\n                \"wasAssociatedWith\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/association\" }\r\n                },\r\n                \"actedOnBehalfOf\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/delegation\" }\r\n                },\r\n                \"wasInfluencedBy\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/influence\" }\r\n                },\r\n                \"specializationOf\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/specialization\" }\r\n                },\r\n                \"alternateOf\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/alternate\" }\r\n                },\r\n                \"hadMember\": {\r\n                    \"type\": \"object\",\r\n                    \"additionalProperties\": { \"$ref\":\"#/definitions/membership\" }\r\n                }\r\n            }\r\n        }\r\n    }\r\n}",
       "Context": {
@@ -4953,6 +1847,850 @@
           }
         },
         "additionalProperties": false
+      },
+      "schema-3": {
+        "definitions": {
+          "DateTime": {
+            "$id": "#/definitions/DateTime",
+            "type": "string",
+            "format": "date-time"
+          },
+          "QualifiedName": {
+            "$id": "#/definitions/QualifiedName",
+            "type": "string",
+            "title": "The QualifiedName Schema",
+            "default": "",
+            "pattern": "(^[A-Za-z0-9_]+:)?(.*)$"
+          },
+          "QualifiedName+": {
+            "$id": "#/definitions/QualifiedName+",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/QualifiedName"
+                }
+              }
+            ]
+          },
+          "non_prov_properties": {
+            "$id": "#/definitions/non_prov_properties",
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {}
+            }
+          },
+          "typed_value": {
+            "type": "object",
+            "required": [
+              "@value",
+              "@type"
+            ],
+            "properties": {
+              "@value": {
+                "type": "string"
+              },
+              "@type": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "lang_string": {
+            "type": "object",
+            "required": [
+              "@value"
+            ],
+            "properties": {
+              "@value": {
+                "type": "string"
+              },
+              "@language": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "ArrayOfValues": {
+            "$id": "#/definitions/ArrayOfValues",
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/QualifiedName"
+                },
+                {
+                  "$ref": "#/components/schemas/typed_value"
+                },
+                {
+                  "$ref": "#/components/schemas/lang_string"
+                }
+              ]
+            }
+          },
+          "ArrayOfLabelValues": {
+            "$id": "#/definitions/ArrayOfLabelValues",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/lang_string"
+            }
+          },
+          "Context": {
+            "$id": "#/definitions/Context",
+            "type": "array",
+            "title": "The @context Schema",
+            "items": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "format": "uri"
+                },
+                {
+                  "type": "object",
+                  "title": "The Items Schema",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              ]
+            }
+          },
+          "prov:StatementOrBundle": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/prov:Statement"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Bundle"
+              }
+            ]
+          },
+          "prov:Statement": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/prov:Entity"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Activity"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Agent"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Usage"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Generation"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Attribution"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Association"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Delegation"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Invalidation"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Start"
+              },
+              {
+                "$ref": "#/components/schemas/prov:End"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Derivation"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Alternate"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Specialization"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Membership"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Influence"
+              },
+              {
+                "$ref": "#/components/schemas/prov:Communication"
+              }
+            ]
+          },
+          "prov:Entity": {
+            "type": "object",
+            "required": [
+              "@type",
+              "@id"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Entity"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "value": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "location": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Agent": {
+            "type": "object",
+            "required": [
+              "@type",
+              "@id"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Agent"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "location": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Activity": {
+            "type": "object",
+            "required": [
+              "@type",
+              "@id"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Activity"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "startTime": {
+                "$ref": "#/components/schemas/DateTime"
+              },
+              "endTime": {
+                "$ref": "#/components/schemas/DateTime"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "location": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Usage": {
+            "type": "object",
+            "required": [
+              "@type"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Usage"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "entity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "activity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "time": {
+                "$ref": "#/components/schemas/DateTime"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "role": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "location": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Generation": {
+            "type": "object",
+            "required": [
+              "@type"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Generation"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "entity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "activity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "time": {
+                "$ref": "#/components/schemas/DateTime"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "role": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "location": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Invalidation": {
+            "type": "object",
+            "required": [
+              "@type"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Invalidation"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "entity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "activity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "time": {
+                "$ref": "#/components/schemas/DateTime"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "role": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "location": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Start": {
+            "type": "object",
+            "required": [
+              "@type"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Start"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "activity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "starter": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "trigger": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "time": {
+                "$ref": "#/components/schemas/DateTime"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "role": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "location": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:End": {
+            "type": "object",
+            "required": [
+              "@type"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "End"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "activity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "ender": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "trigger": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "time": {
+                "$ref": "#/components/schemas/DateTime"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "role": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "location": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Attribution": {
+            "type": "object",
+            "required": [
+              "@type"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Attribution"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "entity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "agent": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Association": {
+            "type": "object",
+            "required": [
+              "@type"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Association"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "activity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "agent": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "plan": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "role": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Delegation": {
+            "type": "object",
+            "required": [
+              "@type"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Delegation"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "delegate": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "responsible": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "activity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Derivation": {
+            "type": "object",
+            "required": [
+              "@type"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Derivation"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "activity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "generation": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "usage": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "generatedEntity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "usedEntity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Alternate": {
+            "type": "object",
+            "required": [
+              "@type"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Alternate"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "alternate1": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "alternate2": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Specialization": {
+            "type": "object",
+            "required": [
+              "@type"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Specialization"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "generalEntity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "specificEntity": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Membership": {
+            "type": "object",
+            "required": [
+              "@type"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Membership"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "entity": {
+                "$ref": "#/components/schemas/QualifiedName+"
+              },
+              "collection": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Influence": {
+            "type": "object",
+            "required": [
+              "@type"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Influence"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "influencer": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "influencee": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Communication": {
+            "type": "object",
+            "required": [
+              "@type"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Communication"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "informant": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "informed": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "type": {
+                "$ref": "#/components/schemas/ArrayOfValues"
+              },
+              "label": {
+                "$ref": "#/components/schemas/ArrayOfLabelValues"
+              }
+            },
+            "patternProperties": {
+              "^[A-Za-z0-9_]+:(.*)$": {
+                "$ref": "#/definitions/ArrayOfValues"
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Bundle": {
+            "type": "object",
+            "required": [
+              "@type",
+              "@id",
+              "@graph",
+              "@context"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Bundle"
+              },
+              "@id": {
+                "$ref": "#/components/schemas/QualifiedName"
+              },
+              "@context": {
+                "$ref": "#/components/schemas/Context"
+              },
+              "@graph": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/prov:Statement"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "prov:Document": {
+            "type": "object",
+            "required": [
+              "@context",
+              "@graph"
+            ],
+            "properties": {
+              "@type": {
+                "pattern": "Document"
+              },
+              "@context": {
+                "$ref": "#/components/schemas/Context"
+              },
+              "@graph": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/prov:StatementOrBundle"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "https://openprovenance.org/prov-jsonld/schema.json",
+        "$ref": "#/components/schemas/prov:Document"
       },
       "common-core-confClasses": {
         "type": "object",
@@ -6616,7 +4354,7 @@
                         ]
                       },
                       "value": {
-                        "$ref": "#/components/schemas/CWL-2"
+                        "$ref": "#/components/schemas/cwl-cwl-json-schema"
                       }
                     }
                   },
@@ -8851,7 +6589,7 @@
           },
           "application/ld+json": {
             "schema": {
-              "$ref": "#/components/schemas/prov:Document"
+              "$ref": "#/components/schemas/schema-3"
             }
           },
           "application/provenance+xml": {

--- a/openapi/ogcapi-processes.bundled.json
+++ b/openapi/ogcapi-processes.bundled.json
@@ -165,17 +165,17 @@
             },
             "application/cwl": {
               "schema": {
-                "$ref": "#/components/schemas/cwl-cwl-json-schema"
+                "$ref": "#/components/schemas/cwl-CWL"
               }
             },
             "application/cwl+json": {
               "schema": {
-                "$ref": "#/components/schemas/cwl-cwl-json-schema"
+                "$ref": "#/components/schemas/cwl-CWL"
               }
             },
             "application/cwl+yaml": {
               "schema": {
-                "$ref": "#/components/schemas/cwl-cwl-json-schema"
+                "$ref": "#/components/schemas/cwl-CWL"
               }
             }
           }
@@ -223,17 +223,17 @@
             },
             "application/cwl": {
               "schema": {
-                "$ref": "#/components/schemas/cwl-cwl-json-schema"
+                "$ref": "#/components/schemas/cwl-CWL"
               }
             },
             "application/cwl+json": {
               "schema": {
-                "$ref": "#/components/schemas/cwl-cwl-json-schema"
+                "$ref": "#/components/schemas/cwl-CWL"
               }
             },
             "application/cwl+yaml": {
               "schema": {
-                "$ref": "#/components/schemas/cwl-cwl-json-schema"
+                "$ref": "#/components/schemas/cwl-CWL"
               }
             }
           }
@@ -279,17 +279,17 @@
             },
             "application/cwl": {
               "schema": {
-                "$ref": "#/components/schemas/cwl-cwl-json-schema"
+                "$ref": "#/components/schemas/cwl-CWL"
               }
             },
             "application/cwl+json": {
               "schema": {
-                "$ref": "#/components/schemas/cwl-cwl-json-schema"
+                "$ref": "#/components/schemas/cwl-CWL"
               }
             },
             "application/cwl+yaml": {
               "schema": {
-                "$ref": "#/components/schemas/cwl-cwl-json-schema"
+                "$ref": "#/components/schemas/cwl-CWL"
               }
             }
           }
@@ -376,17 +376,17 @@
               },
               "application/cwl": {
                 "schema": {
-                  "$ref": "#/components/schemas/cwl-cwl-json-schema"
+                  "$ref": "#/components/schemas/cwl-CWL"
                 }
               },
               "application/cwl+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/cwl-cwl-json-schema"
+                  "$ref": "#/components/schemas/cwl-CWL"
                 }
               },
               "application/cwl+yaml": {
                 "schema": {
-                  "$ref": "#/components/schemas/cwl-cwl-json-schema"
+                  "$ref": "#/components/schemas/cwl-CWL"
                 }
               }
             }
@@ -788,7 +788,7 @@
     "schemas": {
       "CWLWorkflowStepWhen": {
         "description": "Condition to execute a step that must evaluate to a boolean-like value.",
-        "$ref": "#/components/schemas/cwl-cwl-json-schema"
+        "$ref": "#/components/schemas/cwl-CWLExpression"
       },
       "CQL2": {
         "$ref": "#/components/schemas/cql2-cql2"
@@ -2705,7 +2705,8 @@
               "example": "http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/core"
             }
           }
-        }
+        },
+        "title": "confClasses"
       },
       "common-core-link": {
         "type": "object",
@@ -2731,7 +2732,8 @@
           "title": {
             "type": "string"
           }
-        }
+        },
+        "title": "link"
       },
       "common-core-landingPage": {
         "type": "object",
@@ -2758,7 +2760,8 @@
               "$ref": "#/components/schemas/common-core-link"
             }
           }
-        }
+        },
+        "title": "landingPage"
       },
       "common-core-exception": {
         "title": "Exception Schema",
@@ -2815,7 +2818,8 @@
               "$ref": "#/components/schemas/common-geodata-collectionDesc"
             }
           }
-        }
+        },
+        "title": "collections"
       },
       "common-geodata-collectionDesc": {
         "allOf": [
@@ -2830,7 +2834,8 @@
               }
             }
           }
-        ]
+        ],
+        "title": "collectionDesc"
       },
       "common-geodata-extent": {
         "title": "Extent with (optional) Uniform Additional Dimensions Schema",
@@ -2950,7 +2955,8 @@
               "coverage"
             ]
           }
-        ]
+        ],
+        "title": "dataType"
       },
       "common-geodata-timeStamp": {
         "title": "Time stamp",
@@ -2973,15 +2979,2338 @@
         "minimum": 0,
         "example": 127
       },
-      "cwl-cwl-json-schema": {
-        "allOf": [
+      "cwl-CWL": {
+        "oneOf": [
           {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
+            "$ref": "#/components/schemas/cwl-CWLAtomic"
           },
           {
-            "$ref": "#/components/schemas/cwl-cwl-json-schema"
+            "$ref": "#/components/schemas/cwl-CWLGraph"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflow"
+          }
+        ],
+        "title": "CWL"
+      },
+      "cwl-cwltool_CUDARequirement": {
+        "type": "object",
+        "title": "cwltool:CUDARequirement",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "cwltool:CUDARequirement"
+            ]
+          },
+          "cudaVersionMin": {
+            "type": "string",
+            "title": "CUDA version minimum",
+            "description": "The minimum CUDA version required to run the software. This corresponds to a CUDA SDK release.\n\nWhen run in a container, the container image should provide the CUDA runtime,\nand the host driver is injected into the container.  In this case, because CUDA drivers\nare backwards compatible, it is possible to use an older SDK with a newer driver across major versions.\n\nSee https://docs.nvidia.com/deploy/cuda-compatibility/ for details.\n",
+            "example": "11.4",
+            "pattern": "^\\d+\\.\\d+$"
+          },
+          "cudaComputeCapability": {
+            "$ref": "#/components/schemas/cwl-CUDAComputeCapability"
+          },
+          "cudaDeviceCountMin": {
+            "type": "integer",
+            "title": "CUDA device count minimum",
+            "description": "The minimum amount of devices required.",
+            "default": 1,
+            "example": 1,
+            "minimum": 1
+          },
+          "cudaDeviceCountMax": {
+            "type": "integer",
+            "title": "CUDA device count maximum",
+            "description": "The maximum amount of devices required.",
+            "default": 1,
+            "example": 8,
+            "minimum": 1
+          }
+        },
+        "required": [
+          "cudaVersionMin",
+          "cudaComputeCapability"
+        ],
+        "additionalProperties": false
+      },
+      "cwl-CWLAtomic": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLVersion"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLMetadata"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLDocumentation"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLAtomicBase"
+          }
+        ],
+        "title": "CWLAtomic"
+      },
+      "cwl-CWLAtomicNested": {
+        "description": "Same as 'CWLAtomic', but 'cwlVersion' not repeated (only at root).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLMetadata"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLDocumentation"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLAtomicBase"
+          }
+        ],
+        "title": "CWLAtomicNested"
+      },
+      "cwl-CWLGraph": {
+        "title": "CWLGraph",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLVersion"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLMetadata"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLDocumentation"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLGraphBase"
           }
         ]
+      },
+      "cwl-CWLWorkflow": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLVersion"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLMetadata"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLDocumentation"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowClass"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowBase"
+          }
+        ],
+        "title": "CWLWorkflow"
+      },
+      "cwl-CWLWorkflowClass": {
+        "type": "object",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "Workflow"
+            ]
+          }
+        },
+        "title": "CWLWorkflowClass"
+      },
+      "cwl-CWLWorkflowBase": {
+        "type": "object",
+        "properties": {
+          "steps": {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowSteps"
+          },
+          "inputs": {
+            "$ref": "#/components/schemas/cwl-CWLInputsDefinition"
+          },
+          "outputs": {
+            "$ref": "#/components/schemas/cwl-CWLOutputsDefinition"
+          },
+          "requirements": {
+            "description": "Technically a different subset, but lots of redefinitions to be done.",
+            "$ref": "#/components/schemas/cwl-CWLRequirements"
+          },
+          "hints": {
+            "description": "Technically a different subset, but lots of redefinitions to be done.",
+            "$ref": "#/components/schemas/cwl-CWLHints"
+          }
+        },
+        "title": "CWLWorkflowBase"
+      },
+      "cwl-CWLWorkflowSteps": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepMap"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepList"
+          }
+        ],
+        "title": "CWLWorkflowSteps"
+      },
+      "cwl-CWLInputsDefinition": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLInputList"
+          },
+          {
+            "description": "Avoid 'oneOf' conflict of generic mapping key strings as input identifier matching against '$import'.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/cwl-CWLInputMap"
+              },
+              {
+                "not": {
+                  "$ref": "#/components/schemas/cwl-CWLImport"
+                }
+              }
+            ]
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLImport"
+          }
+        ],
+        "title": "CWLInputsDefinition",
+        "description": "All inputs available to the Application Package."
+      },
+      "cwl-CWLOutputsDefinition": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLOutputList"
+          },
+          {
+            "description": "Avoid 'oneOf' conflict of generic mapping key strings as output identifier matching against '$import'.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/cwl-CWLOutputMap"
+              },
+              {
+                "not": {
+                  "$ref": "#/components/schemas/cwl-CWLImport"
+                }
+              }
+            ]
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLImport"
+          }
+        ],
+        "title": "CWLOutputsDefinition",
+        "description": "All outputs produced by the Application Package."
+      },
+      "cwl-CWLWorkflowStepMap": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/cwl-CWLWorkflowStepObject"
+        },
+        "title": "CWLWorkflowStepMap"
+      },
+      "cwl-CWLWorkflowStepList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/cwl-CWLWorkflowStepItem"
+        },
+        "title": "CWLWorkflowStepList"
+      },
+      "cwl-CWLInputList": {
+        "type": "array",
+        "title": "CWLInputList",
+        "description": "Package inputs defined as items.",
+        "items": {
+          "$ref": "#/components/schemas/cwl-CWLInputItem"
+        }
+      },
+      "cwl-CWLInputMap": {
+        "type": "object",
+        "title": "CWLInputMap",
+        "description": "Package inputs defined as mapping.",
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/cwl-CWLType"
+            },
+            {
+              "$ref": "#/components/schemas/cwl-CWLInputObject"
+            },
+            {
+              "$ref": "#/components/schemas/cwl-CWLInputStdIn"
+            },
+            {
+              "$ref": "#/components/schemas/cwl-CWLImport"
+            }
+          ]
+        }
+      },
+      "cwl-ResourceQuantityOrFractional": {
+        "title": "An item quantity that can also represent a proportion of use by resources.",
+        "description": "Technically should be minimum=1, but fractional for scheduling algorithms are allowed.\nThere is no way to distinguish between float/long simultaneously in JSON schema (multi-match oneOf).\nTherefore, only validate that it is greater than zero.\n",
+        "type": "number",
+        "exclusiveMinimum": true,
+        "minimum": 0,
+        "default": 1
+      },
+      "cwl-CWLExpression": {
+        "type": "string",
+        "title": "CWLExpression",
+        "description": "When combined with 'InlineJavascriptRequirement', this field allows runtime parameter references\n(see also: https://www.commonwl.org/v1.2/CommandLineTool.html#Expression).\nWhenever this option is applicable for a parameter, any other 'normal' string should not be specified.\nFor JSON schema validation, there is no easy way to distinguish them unless using complicated string patterns.\n"
+      },
+      "cwl-InitialWorkDirListing": {
+        "title": "InitialWorkDirListing",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          },
+          {
+            "type": "array",
+            "title": "InitialWorkDirListingItems",
+            "items": {
+              "oneOf": [
+                {
+                  "nullable": true,
+                  "enum": [
+                    null
+                  ]
+                },
+                {
+                  "$ref": "#/components/schemas/cwl-CWLExpression"
+                },
+                {
+                  "$ref": "#/components/schemas/cwl-DirectoryListingDirent"
+                },
+                {
+                  "$ref": "#/components/schemas/cwl-DirectoryListingFileOrDirectory"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/cwl-DirectoryListingFileOrDirectory"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "cwl-CWLRequirementsMap": {
+        "title": "CWLRequirementsMap",
+        "type": "object",
+        "properties": {
+          "cwltool:CUDARequirement": {
+            "$ref": "#/components/schemas/cwl-cwltool_CUDARequirement"
+          },
+          "DockerRequirement": {
+            "$ref": "#/components/schemas/cwl-DockerRequirement"
+          },
+          "SoftwareRequirement": {
+            "$ref": "#/components/schemas/cwl-SoftwareRequirement"
+          },
+          "ShellCommandRequirement": {
+            "$ref": "#/components/schemas/cwl-ShellCommandRequirement"
+          },
+          "EnvVarRequirement": {
+            "$ref": "#/components/schemas/cwl-EnvVarRequirement"
+          },
+          "SchemaDefRequirement": {
+            "$ref": "#/components/schemas/cwl-SchemaDefRequirement"
+          },
+          "InitialWorkDirRequirement": {
+            "$ref": "#/components/schemas/cwl-InitialWorkDirRequirement"
+          },
+          "InlineJavascriptRequirement": {
+            "$ref": "#/components/schemas/cwl-InlineJavascriptRequirement"
+          },
+          "InplaceUpdateRequirement": {
+            "$ref": "#/components/schemas/cwl-InplaceUpdateRequirement"
+          },
+          "LoadListingRequirement": {
+            "$ref": "#/components/schemas/cwl-LoadListingRequirement"
+          },
+          "NetworkAccess": {
+            "allOf": [
+              {
+                "description": "Not 'NetworkAccessRequirement'"
+              },
+              {
+                "$ref": "#/components/schemas/cwl-NetworkAccessRequirement"
+              }
+            ]
+          },
+          "ResourceRequirement": {
+            "$ref": "#/components/schemas/cwl-ResourceRequirement"
+          },
+          "ScatterFeatureRequirement": {
+            "$ref": "#/components/schemas/cwl-ScatterFeatureRequirement"
+          },
+          "ToolTimeLimit": {
+            "allOf": [
+              {
+                "description": "Not 'ToolTimeLimitRequirement'"
+              },
+              {
+                "$ref": "#/components/schemas/cwl-ToolTimeLimitRequirement"
+              }
+            ]
+          },
+          "WorkReuse": {
+            "allOf": [
+              {
+                "description": "Not 'WorkReuseRequirement'"
+              },
+              {
+                "$ref": "#/components/schemas/cwl-WorkReuseRequirement"
+              }
+            ]
+          },
+          "MultipleInputFeatureRequirement": {
+            "$ref": "#/components/schemas/cwl-MultipleInputFeatureRequirement"
+          },
+          "StepInputExpressionRequirement": {
+            "$ref": "#/components/schemas/cwl-StepInputExpressionRequirement"
+          },
+          "SubworkflowFeatureRequirement": {
+            "$ref": "#/components/schemas/cwl-SubworkflowFeatureRequirement"
+          }
+        },
+        "additionalProperties": false
+      },
+      "cwl-CWLRequirements": {
+        "title": "CWLRequirements",
+        "description": "Explicit requirement to execute the application package.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLRequirementsMap"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLRequirementsList"
+          }
+        ]
+      },
+      "cwl-CWLCommand": {
+        "oneOf": [
+          {
+            "type": "string",
+            "title": "String command."
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CommandParts"
+          }
+        ],
+        "title": "CWLCommand",
+        "description": "Command called in the docker image or on shell according to requirements\nand hints specifications. Can be omitted if already defined in the docker\nimage.\n"
+      },
+      "cwl-InputBinding": {
+        "type": "object",
+        "title": "Input Binding",
+        "description": "Defines how to specify the input for the command.",
+        "properties": {
+          "prefix": {
+            "type": "string"
+          },
+          "position": {
+            "oneOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "$ref": "#/components/schemas/cwl-CWLExpression"
+              }
+            ]
+          },
+          "valueFrom": {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          },
+          "itemSeparator": {
+            "type": "string"
+          },
+          "shellQuote": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "cwl-CWLInputItem": {
+        "title": "Input",
+        "description": "Input specification. Note that multiple formats are supported and\nnot all specification variants or parameters are presented here. Please refer\nto official CWL documentation for more details (https://www.commonwl.org).\n",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLInputItemBase"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLDefaultTypedConditional"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLDocumentation"
+          }
+        ]
+      },
+      "cwl-DirectoryListingDirent": {
+        "description": "Called 'Dirent' in documentation.",
+        "type": "object",
+        "title": "DirectoryListingDirent",
+        "properties": {
+          "entry": {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          },
+          "entryname": {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          },
+          "writable": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "entry"
+        ],
+        "additionalProperties": false
+      },
+      "cwl-DirectoryListingFileOrDirectory": {
+        "type": "object",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "File",
+              "Directory"
+            ]
+          },
+          "location": {
+            "type": "string"
+          },
+          "checksum": {
+            "$ref": "#/components/schemas/cwl-Checksum"
+          },
+          "size": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "class",
+          "location"
+        ],
+        "additionalProperties": false,
+        "title": "DirectoryListingFileOrDirectory"
+      },
+      "cwl-SoftwareRequirement": {
+        "type": "object",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "SoftwareRequirement"
+            ]
+          },
+          "packages": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/cwl-SoftwarePackage"
+                }
+              },
+              {
+                "type": "object",
+                "description": "Mapping of 'package' name to its specifications.",
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/cwl-SoftwarePackageSpecs"
+                    },
+                    {
+                      "$ref": "#/components/schemas/cwl-SoftwarePackage"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "packages"
+        ],
+        "additionalProperties": false,
+        "title": "SoftwareRequirement"
+      },
+      "cwl-DockerRequirement": {
+        "type": "object",
+        "title": "DockerRequirement",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "DockerRequirement"
+            ]
+          },
+          "dockerPull": {
+            "type": "string",
+            "title": "Docker pull reference",
+            "description": "Reference package that will be retrieved and executed by CWL.",
+            "example": "docker-registry.host.com/namespace/image:1.2.3"
+          },
+          "dockerImport": {
+            "type": "string"
+          },
+          "dockerLoad": {
+            "type": "string"
+          },
+          "dockerFile": {
+            "type": "string"
+          },
+          "dockerImageId": {
+            "type": "string"
+          },
+          "dockerOutputDirectory": {
+            "type": "string"
+          }
+        },
+        "oneOf": [
+          {
+            "required": [
+              "dockerPull"
+            ]
+          },
+          {
+            "required": [
+              "dockerImport"
+            ]
+          },
+          {
+            "required": [
+              "dockerLoad"
+            ]
+          },
+          {
+            "required": [
+              "dockerFile"
+            ]
+          }
+        ],
+        "additionalProperties": false
+      },
+      "cwl-ShellCommandRequirement": {
+        "type": "object",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "ShellCommandRequirement"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "title": "ShellCommandRequirement"
+      },
+      "cwl-EnvVarRequirement": {
+        "type": "object",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "EnvVarRequirement"
+            ]
+          },
+          "envDef": {
+            "oneOf": [
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/cwl-EnvironmentDef"
+                }
+              },
+              {
+                "type": "object",
+                "description": "Mapping of 'envName' to environment value or definition.",
+                "additionalProperties": {
+                  "oneOf": [
+                    {
+                      "description": "The 'envValue' specified directly",
+                      "$ref": "#/components/schemas/cwl-CWLExpression"
+                    },
+                    {
+                      "$ref": "#/components/schemas/cwl-EnvironmentDef"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "envDef"
+        ],
+        "additionalProperties": false,
+        "title": "EnvVarRequirement"
+      },
+      "cwl-SchemaDefRequirement": {
+        "type": "object",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "SchemaDefRequirement"
+            ]
+          },
+          "types": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/cwl-CWLTypeEnum"
+                },
+                {
+                  "$ref": "#/components/schemas/cwl-CWLTypeRecordSchema"
+                },
+                {
+                  "$ref": "#/components/schemas/cwl-CWLTypeRecordArray"
+                },
+                {
+                  "$ref": "#/components/schemas/cwl-CWLImport"
+                }
+              ]
+            }
+          }
+        },
+        "required": [
+          "types"
+        ],
+        "additionalProperties": false,
+        "title": "SchemaDefRequirement"
+      },
+      "cwl-InitialWorkDirRequirement": {
+        "type": "object",
+        "title": "InitialWorkDirRequirement",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "InitialWorkDirRequirement"
+            ]
+          },
+          "listing": {
+            "$ref": "#/components/schemas/cwl-InitialWorkDirListing"
+          }
+        },
+        "required": [
+          "listing"
+        ],
+        "additionalProperties": false
+      },
+      "cwl-InlineJavascriptRequirement": {
+        "type": "object",
+        "title": "InlineJavascriptRequirement",
+        "description": "Indicates that the workflow platform must support inline Javascript expressions.\n\nIf this requirement is not present, the workflow platform must not perform expression interpolation\n(see also: https://www.commonwl.org/v1.2/CommandLineTool.html#InlineJavascriptRequirement).\n",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "InlineJavascriptRequirement"
+            ]
+          },
+          "expressionLib": {
+            "$ref": "#/components/schemas/cwl-InlineJavascriptLibraries"
+          }
+        },
+        "required": [
+          "expressionLib"
+        ],
+        "additionalProperties": false
+      },
+      "cwl-InplaceUpdateRequirement": {
+        "type": "object",
+        "title": "InplaceUpdateRequirement",
+        "description": "If 'inplaceUpdate' is true, then an implementation supporting this feature may permit tools to directly\nupdate files with 'writable: true' in 'InitialWorkDirRequirement'. That is, as an optimization,\nfiles may be destructively modified in place as opposed to copied and updated\n(see also: https://www.commonwl.org/v1.2/CommandLineTool.html#InplaceUpdateRequirement).\n",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "InplaceUpdateRequirement"
+            ]
+          },
+          "inplaceUpdate": {
+            "type": "boolean",
+            "title": "inplaceUpdate"
+          }
+        },
+        "required": [
+          "inplaceUpdate"
+        ],
+        "additionalProperties": false
+      },
+      "cwl-LoadListingRequirement": {
+        "type": "object",
+        "title": "LoadListingRequirement",
+        "description": "Specify the desired behavior for loading the listing field of a 'Directory' object for use by expressions\n(see also: https://www.commonwl.org/v1.2/CommandLineTool.html#LoadListingRequirement).\n",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "LoadListingRequirement"
+            ]
+          },
+          "loadListing": {
+            "$ref": "#/components/schemas/cwl-LoadListingEnum"
+          }
+        },
+        "required": [
+          "loadListing"
+        ],
+        "additionalProperties": false
+      },
+      "cwl-NetworkAccessRequirement": {
+        "type": "object",
+        "title": "NetworkAccessRequirement",
+        "properties": {
+          "class": {
+            "type": "string",
+            "description": "Not 'NetworkAccessRequirement'",
+            "enum": [
+              "NetworkAccess"
+            ]
+          },
+          "networkAccess": {
+            "$ref": "#/components/schemas/cwl-NetworkAccess"
+          }
+        },
+        "required": [
+          "networkAccess"
+        ],
+        "additionalProperties": false
+      },
+      "cwl-ResourceRequirement": {
+        "type": "object",
+        "title": "ResourceRequirement",
+        "description": "Specify basic hardware resource requirements\n(see also: https://www.commonwl.org/v1.2/CommandLineTool.html#ResourceRequirement).\n",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "ResourceRequirement"
+            ]
+          },
+          "coresMin": {
+            "$ref": "#/components/schemas/cwl-ResourceCoresMinimum"
+          },
+          "coresMax": {
+            "$ref": "#/components/schemas/cwl-ResourceCoresMaximum"
+          },
+          "ramMin": {
+            "$ref": "#/components/schemas/cwl-ResourceRAMMinimum"
+          },
+          "ramMax": {
+            "$ref": "#/components/schemas/cwl-ResourceRAMMaximum"
+          },
+          "tmpdirMin": {
+            "$ref": "#/components/schemas/cwl-ResourceTmpDirMinimum"
+          },
+          "tmpdirMax": {
+            "$ref": "#/components/schemas/cwl-ResourceTmpDirMaximum"
+          },
+          "outdirMin": {
+            "$ref": "#/components/schemas/cwl-ResourceOutDirMinimum"
+          },
+          "outdirMax": {
+            "$ref": "#/components/schemas/cwl-ResourceOutDirMaximum"
+          }
+        },
+        "additionalProperties": false
+      },
+      "cwl-ScatterFeatureRequirement": {
+        "type": "object",
+        "title": "ScatterFeatureRequirement",
+        "description": "A 'scatter' operation specifies that the associated Workflow step should execute separately over a list of\ninput elements. Each job making up a scatter operation is independent and may be executed concurrently\n(see also: https://www.commonwl.org/v1.2/Workflow.html#WorkflowStep).\nFields 'scatter' and 'scatterMethod' at the root of a 'WorkflowStep', not within the requirement.\n",
+        "properties": {
+          "class": {
+            "type": "string",
+            "description": "CWL requirement class specification.",
+            "enum": [
+              "ScatterFeatureRequirement"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "cwl-WorkReuseRequirement": {
+        "type": "object",
+        "title": "WorkReuseRequirement",
+        "description": "For implementations that support reusing output from past work\n(on the assumption that same code and same input produce same results),\ncontrol whether to enable or disable the reuse behavior for a particular tool\nor step (to accommodate situations where that assumption is incorrect).\nA reused step is not executed but instead returns the same output as the original execution.\nIf 'WorkReuse' is not specified, correct tools should assume it is enabled by default.\n",
+        "properties": {
+          "class": {
+            "type": "string",
+            "description": "Not 'WorkReuseRequirement'.",
+            "enum": [
+              "WorkReuse"
+            ]
+          },
+          "enableReuse": {
+            "$ref": "#/components/schemas/cwl-EnableReuseValue"
+          }
+        },
+        "required": [
+          "enableReuse"
+        ],
+        "additionalProperties": false
+      },
+      "cwl-ToolTimeLimitRequirement": {
+        "type": "object",
+        "title": "ToolTimeLimitRequirement",
+        "description": "Set an upper limit on the execution time of a CommandLineTool.\n\nA CommandLineTool whose execution duration exceeds the time limit may be preemptively\nterminated and considered failed. May also be used by batch systems to make scheduling decisions.\n\nThe execution duration excludes external operations, such as staging of files,\npulling a docker image etc., and only counts wall-time for the execution of the command line itself.\n",
+        "properties": {
+          "class": {
+            "type": "string",
+            "description": "not 'ToolTimeLimitRequirement'",
+            "enum": [
+              "ToolTimeLimit"
+            ]
+          },
+          "timelimit": {
+            "$ref": "#/components/schemas/cwl-TimeLimitValue"
+          }
+        },
+        "required": [
+          "timelimit"
+        ],
+        "additionalProperties": false
+      },
+      "cwl-MultipleInputFeatureRequirement": {
+        "type": "object",
+        "title": "MultipleInputFeatureRequirement",
+        "description": "Indicates that the 'Workflow' must support multiple inbound data links listed in the 'source'\nfield of 'WorkflowStepInput'.\n",
+        "properties": {
+          "class": {
+            "type": "string",
+            "description": "CWL requirement class specification.",
+            "enum": [
+              "MultipleInputFeatureRequirement"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "cwl-StepInputExpressionRequirement": {
+        "type": "object",
+        "title": "StepInputExpressionRequirement",
+        "description": "Indicates that the 'Workflow' must support the 'valueFrom' field of 'WorkflowStepInput'.",
+        "properties": {
+          "class": {
+            "type": "string",
+            "description": "CWL requirement class specification.",
+            "enum": [
+              "StepInputExpressionRequirement"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "cwl-SubworkflowFeatureRequirement": {
+        "type": "object",
+        "title": "SubworkflowFeatureRequirement",
+        "description": "Indicates that the 'Workflow' must support nested workflows in the 'run' field of 'WorkflowStep'.",
+        "properties": {
+          "class": {
+            "type": "string",
+            "description": "CWL requirement class specification.",
+            "enum": [
+              "SubworkflowFeatureRequirement"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "cwl-CWLHints": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLHintsMap"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLHintsList"
+          }
+        ],
+        "title": "CWLHints",
+        "description": "Non-failing additional hints that can help resolve extra requirements."
+      },
+      "cwl-CWLWorkflowStepDefinition": {
+        "type": "object",
+        "properties": {
+          "in": {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepIn"
+          },
+          "run": {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepRun"
+          },
+          "when": {
+            "$ref": "#/components/schemas/CWLWorkflowStepWhen"
+          },
+          "out": {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepOut"
+          }
+        },
+        "required": [
+          "in",
+          "run",
+          "out"
+        ],
+        "title": "CWLWorkflowStepDefinition"
+      },
+      "cwl-CWLWorkflowStepScatter": {
+        "type": "object",
+        "properties": {
+          "scatter": {
+            "$ref": "#/components/schemas/cwl-Scatter"
+          },
+          "scatterMethod": {
+            "$ref": "#/components/schemas/cwl-ScatterMethod"
+          }
+        },
+        "title": "CWLWorkflowStepScatter"
+      },
+      "cwl-CWLWorkflowStepId": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/cwl-CWLIdentifier"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "CWLWorkflowStepId"
+      },
+      "cwl-CWLHintsMap": {
+        "title": "CWLHintsMap",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLRequirementsMap"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLHintsMapExtras"
+          }
+        ]
+      },
+      "cwl-CWLHintsList": {
+        "type": "array",
+        "title": "CWLHintsList",
+        "items": {
+          "oneOf": [
+            {
+              "allOf": [
+                {
+                  "description": "When using the list representation, 'class' is required to indicate which one is being represented.\nWhen using the mapping representation, 'class' is optional since it's the key, but it must match by name.\n",
+                  "required": [
+                    "class"
+                  ]
+                },
+                {
+                  "$ref": "#/components/schemas/cwl-CWLHintsItem"
+                }
+              ]
+            },
+            {
+              "$ref": "#/components/schemas/cwl-CWLImport"
+            }
+          ]
+        }
+      },
+      "cwl-CWLWorkflowStepIn": {
+        "description": "Mapping of Workflow step inputs to nested CWL tool definitions inputs or outputs.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepInMap"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepInList"
+          }
+        ],
+        "title": "CWLWorkflowStepIn"
+      },
+      "cwl-CWLWorkflowStepRun": {
+        "description": "Nested CWL definition to run as Workflow step.",
+        "oneOf": [
+          {
+            "description": "File or URL reference to a CWL tool definition.",
+            "type": "string"
+          },
+          {
+            "description": "Nested CWL tool definition for the step.",
+            "$ref": "#/components/schemas/cwl-CWLAtomicNested"
+          },
+          {
+            "description": "Nested CWL Workflow definition for the step.",
+            "$ref": "#/components/schemas/cwl-CWLWorkflowNested"
+          }
+        ],
+        "title": "CWLWorkflowStepRun"
+      },
+      "cwl-CWLWorkflowStepOut": {
+        "description": "Mapping of Workflow step inputs to nested CWL tool definitions inputs or outputs.",
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/cwl-CWLIdentifier"
+            },
+            {
+              "$ref": "#/components/schemas/cwl-CWLWorkflowStepOutId"
+            }
+          ]
+        },
+        "title": "CWLWorkflowStepOut"
+      },
+      "cwl-CWLWorkflowStepInMap": {
+        "type": "object",
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "$ref": "#/components/schemas/cwl-CWLWorkflowStepInput"
+            }
+          ]
+        },
+        "title": "CWLWorkflowStepInMap"
+      },
+      "cwl-CWLWorkflowStepInList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/cwl-CWLWorkflowStepInItem"
+        },
+        "title": "CWLWorkflowStepInList"
+      },
+      "cwl-CWLWorkflowStepInItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepInputId"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepInputBase"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepInputDefault"
+          }
+        ],
+        "title": "CWLWorkflowStepInItem"
+      },
+      "cwl-CWLWorkflowStepInputId": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/cwl-CWLIdentifier"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "CWLWorkflowStepInputId"
+      },
+      "cwl-CWLWorkflowStepInputBase": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "linkMerge": {
+            "$ref": "#/components/schemas/cwl-LinkMergeMethod"
+          },
+          "valueFrom": {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          }
+        },
+        "title": "CWLWorkflowStepInputBase"
+      },
+      "cwl-CWLWorkflowStepInputDefault": {
+        "description": "CWL 'type' is not specified at this level for step inputs\n(it is provided by the mapped input of the nested tool instead).\nTherefore, cannot validate against 'CWLDefaultTypedConditional'.\n",
+        "type": "object",
+        "properties": {
+          "default": {
+            "$ref": "#/components/schemas/cwl-CWLDefault"
+          }
+        },
+        "title": "CWLWorkflowStepInputDefault"
+      },
+      "cwl-NetworkAccess": {
+        "title": "NetworkAccess",
+        "description": "Indicate whether a process requires outgoing IPv4/IPv6 network access.",
+        "example": true,
+        "oneOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          }
+        ]
+      },
+      "cwl-EnvironmentDef": {
+        "type": "object",
+        "properties": {
+          "envName": {
+            "type": "string",
+            "minLength": 1
+          },
+          "envValue": {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          }
+        },
+        "required": [
+          "envName",
+          "envValue"
+        ],
+        "additionalProperties": false,
+        "title": "EnvironmentDef"
+      },
+      "cwl-CWLType": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLTypeBase"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLTypeList"
+          }
+        ],
+        "title": "CWL Type"
+      },
+      "cwl-CWLOutputObject": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLDocumentation"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLOutputObjectBase"
+          }
+        ],
+        "title": "CWLOutputObject"
+      },
+      "cwl-CWLOutputStdOut": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLOutputStdOutDefinition"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLOutputStdOutObjectType"
+          }
+        ],
+        "title": "CWLOutputStdOut"
+      },
+      "cwl-CWLOutputStdErr": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLOutputStdErrDefinition"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLOutputStdErrObjectType"
+          }
+        ],
+        "title": "CWLOutputStdErr"
+      },
+      "cwl-CWLTypeEnum": {
+        "type": "object",
+        "title": "CWLTypeEnum (CWL type as enum of values).",
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "type",
+            "example": "enum",
+            "enum": [
+              "enum"
+            ]
+          },
+          "symbols": {
+            "$ref": "#/components/schemas/cwl-CWLTypeSymbols"
+          }
+        },
+        "required": [
+          "type",
+          "symbols"
+        ]
+      },
+      "cwl-CWLTypeRecordSchema": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "record"
+            ]
+          },
+          "fields": {
+            "$ref": "#/components/schemas/cwl-CWLTypeRecordFields"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "CWLTypeRecordSchema"
+      },
+      "cwl-CWLTypeRecordArray": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "array"
+            ]
+          },
+          "items": {
+            "$ref": "#/components/schemas/cwl-CWLType"
+          }
+        },
+        "required": [
+          "type",
+          "items"
+        ],
+        "title": "CWLTypeRecordArray"
+      },
+      "cwl-CWLDefaultTypedConditional": {
+        "description": "Validate that the 'default' value, if specified, is of same type as the CWL 'type'.\nThis avoids over-accepting anything that does not match the intended type.\nHowever, validation limits itself to data literals and arrays.\nNested type and multi-type definitions will validate against 'Any'.\n",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "null"
+                ]
+              },
+              "default": {
+                "nullable": true,
+                "enum": [
+                  null
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "string",
+                  "string?"
+                ]
+              },
+              "default": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "boolean",
+                  "boolean?"
+                ]
+              },
+              "default": {
+                "type": "boolean",
+                "nullable": true
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "int",
+                  "int?",
+                  "long",
+                  "long?",
+                  "float",
+                  "float?",
+                  "double",
+                  "double?",
+                  "integer",
+                  "integer?"
+                ]
+              },
+              "default": {
+                "type": "number",
+                "nullable": true
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "File",
+                  "File?",
+                  "Directory",
+                  "Directory?"
+                ]
+              },
+              "default": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/cwl-CWLDefaultLocation"
+                  },
+                  {
+                    "nullable": true,
+                    "enum": [
+                      null
+                    ]
+                  }
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "pattern": "^[a-zA-Z]+\\\\[\\\\]$"
+              },
+              "default": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/cwl-AnyType"
+                }
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "array"
+                ]
+              },
+              "items": {
+                "$ref": "#/components/schemas/cwl-AnyType"
+              },
+              "default": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/cwl-AnyType"
+                }
+              }
+            },
+            "required": [
+              "type",
+              "items"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "enum",
+                  "enum?"
+                ]
+              },
+              "symbols": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "default": {
+                "type": "string",
+                "nullable": true
+              }
+            },
+            "required": [
+              "type",
+              "symbols"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "Any",
+                  "Any?"
+                ]
+              },
+              "default": {
+                "$ref": "#/components/schemas/cwl-AnyType"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ],
+        "title": "CWLDefaultTypedConditional"
+      },
+      "cwl-CWLTypeBase": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLTypeDefinition"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLTypeArray"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLTypeEnum"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLTypeRecordRef"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLTypeRecordSchema"
+          }
+        ],
+        "title": "CWLTypeBase"
+      },
+      "cwl-CWLTypeList": {
+        "type": "array",
+        "title": "CWLTypeList (Combination of allowed CWL types).",
+        "items": {
+          "$ref": "#/components/schemas/cwl-CWLTypeBase"
+        }
+      },
+      "cwl-AnyType": {
+        "oneOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {}
+          },
+          {
+            "type": "object"
+          }
+        ],
+        "title": "AnyType"
+      },
+      "cwl-CWLTypeDefinition": {
+        "type": "string",
+        "title": "CWL type string definition",
+        "description": "Note that 'Any' is equivalent to any of the non-null types.\nTherefore, a nullable 'Any' explicitly specified by 'Any?' or its array-nullable form 'Any[]?' are not equivalent.\nField type definition.\n",
+        "enum": [
+          "null",
+          "Any",
+          "Any?",
+          "Any[]",
+          "Any[]?",
+          "Directory",
+          "Directory?",
+          "Directory[]",
+          "Directory[]?",
+          "File",
+          "File?",
+          "File[]",
+          "File[]?",
+          "boolean",
+          "boolean?",
+          "boolean[]",
+          "boolean[]?",
+          "double",
+          "double?",
+          "double[]",
+          "double[]?",
+          "enum?",
+          "enum[]",
+          "enum[]?",
+          "float",
+          "float?",
+          "float[]",
+          "float[]?",
+          "int",
+          "int?",
+          "int[]",
+          "int[]?",
+          "integer",
+          "integer?",
+          "integer[]",
+          "integer[]?",
+          "long",
+          "long?",
+          "long[]",
+          "long[]?",
+          "string",
+          "string?",
+          "string[]",
+          "string[]?"
+        ]
+      },
+      "cwl-CWLTypeArray": {
+        "type": "object",
+        "title": "CWLTypeArray (CWL type as list of items).",
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "type",
+            "example": "array",
+            "enum": [
+              "array"
+            ]
+          },
+          "items": {
+            "$ref": "#/components/schemas/cwl-CWLType"
+          }
+        },
+        "required": [
+          "type",
+          "items"
+        ]
+      },
+      "cwl-CWLTypeRecordRef": {
+        "description": "An IRI with minimally a '{Record}' identifier to look for a schema definition locally or remotely.\n\nThe identifier resolution is performed accordingly to the specified reference and as described in\nhttps://www.commonwl.org/v1.2/SchemaSalad.html#Identifier_resolution.\nAvoid 'oneOf' conflict of valid strings between this CWL record reference and the generic CWL types.\n",
+        "allOf": [
+          {
+            "not": {
+              "$ref": "#/components/schemas/cwl-CWLTypeDefinition"
+            }
+          },
+          {
+            "not": {
+              "$ref": "#/components/schemas/cwl-CWLInputStdInDefinition"
+            }
+          },
+          {
+            "not": {
+              "$ref": "#/components/schemas/cwl-CWLOutputStdOutDefinition"
+            }
+          },
+          {
+            "not": {
+              "$ref": "#/components/schemas/cwl-CWLOutputStdErrDefinition"
+            }
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLTypeRecordRefPattern"
+          }
+        ],
+        "title": "CWLTypeRecordRef"
+      },
+      "cwl-CWLTypeRecordFieldsMap": {
+        "type": "object",
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/cwl-CWLType"
+            },
+            {
+              "$ref": "#/components/schemas/cwl-CWLTypeRecordFieldDef"
+            }
+          ]
+        },
+        "title": "CWLTypeRecordFieldsMap"
+      },
+      "cwl-CWLTypeRecordFieldsList": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/cwl-CWLTypeRecordFieldsItem"
+        },
+        "title": "CWLTypeRecordFieldsList"
+      },
+      "cwl-CWLTypeRecordFieldDefBase": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Required if list item. Otherwise, optional since it is the mapping key.\nThis requirement is defined in 'CWLTypeRecordFieldsItem' to allow reuse of this schema.\n",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/cwl-CWLType"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "CWLTypeRecordFieldDefBase"
+      },
+      "cwl-CWLFileOnlyParametersConditional": {
+        "description": "Explicitly disallow these parameters when non-File type is detected.\nOtherwise, validate their schema definitions according to what is permitted.\nParameters that are only valid when 'type' or 'items' evaluates to 'File'.\n",
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLFileOnlyParameters"
+          },
+          {
+            "not": {
+              "properties": {
+                "secondaryFiles": {},
+                "streamable": {},
+                "format": {},
+                "loadContents": {}
+              }
+            }
+          }
+        ],
+        "title": "CWLFileOnlyParametersConditional"
+      },
+      "cwl-CWLDirectoryOnlyParametersConditional": {
+        "description": "Explicitly disallow these parameters when non-Directory type is detected.\nOtherwise, validate their schema definitions according to what is permitted.\nParameters that are only valid when 'type' or 'items' evaluates to 'Directory'.\n",
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLDirectoryOnlyParameters"
+          },
+          {
+            "not": {
+              "properties": {
+                "loadListing": {}
+              }
+            }
+          }
+        ],
+        "title": "CWLDirectoryOnlyParametersConditional"
+      },
+      "cwl-CWLFileOnlyParameters": {
+        "type": "object",
+        "properties": {
+          "secondaryFiles": {
+            "$ref": "#/components/schemas/cwl-CWLTypeRecordSecondaryFiles"
+          },
+          "streamable": {
+            "type": "boolean"
+          },
+          "format": {
+            "$ref": "#/components/schemas/cwl-CWLFormat"
+          },
+          "loadContents": {
+            "type": "boolean"
+          }
+        },
+        "title": "CWLFileOnlyParameters"
+      },
+      "cwl-CWLTypeRecordSecondaryFiles": {
+        "oneOf": [
+          {
+            "description": "Either an expression or the regex pattern directly.",
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLTypeRecordSecondaryFileSchema"
+          },
+          {
+            "type": "array",
+            "items": {
+              "description": "Either an expression or the regex pattern directly.",
+              "$ref": "#/components/schemas/cwl-CWLExpression"
+            }
+          },
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/cwl-CWLTypeRecordSecondaryFileSchema"
+            }
+          }
+        ],
+        "title": "CWLTypeRecordSecondaryFiles"
+      },
+      "cwl-CWLTypeRecordSecondaryFileSchema": {
+        "type": "object",
+        "properties": {
+          "pattern": {
+            "description": "Either an expression or the regex pattern directly.",
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          },
+          "required": {
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "$ref": "#/components/schemas/cwl-CWLExpression"
+              }
+            ]
+          }
+        },
+        "required": [
+          "pattern"
+        ],
+        "additionalProperties": false,
+        "title": "CWLTypeRecordSecondaryFileSchema"
+      },
+      "cwl-CWLRequirementsList": {
+        "type": "array",
+        "title": "CWLRequirementsList",
+        "items": {
+          "oneOf": [
+            {
+              "allOf": [
+                {
+                  "description": "When using the list representation, 'class' is required to indicate which one is being represented.\nWhen using the mapping representation, 'class' is optional since it's the key, but it must match by name.\n",
+                  "required": [
+                    "class"
+                  ]
+                },
+                {
+                  "$ref": "#/components/schemas/cwl-CWLRequirementsItem"
+                }
+              ]
+            },
+            {
+              "$ref": "#/components/schemas/cwl-CWLImport"
+            }
+          ]
+        }
+      },
+      "cwl-CWLRequirementsItem": {
+        "title": "CWLRequirementsItem",
+        "description": "For any new items added, ensure they are added under 'class' of 'UnknownRequirement' as well.\nOtherwise, insufficiently restrictive classes could cause multiple matches, failing the 'oneOf' condition.\n",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-cwltool_CUDARequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-DockerRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-SoftwareRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-ShellCommandRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-EnvVarRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-SchemaDefRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-InitialWorkDirRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-InlineJavascriptRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-InplaceUpdateRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-LoadListingRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-NetworkAccessRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-ResourceRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-ScatterFeatureRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-ToolTimeLimitRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-WorkReuseRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-MultipleInputFeatureRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-StepInputExpressionRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-SubworkflowFeatureRequirement"
+          }
+        ]
+      },
+      "cwl-CWLOutputStdOutDefinition": {
+        "description": "Indicates that the data pushed to the standard output stream by the command will be redirected to this CWL output.\nCan be defined for only one output. If combined with 'stdout' at the root of the CWL document, that definition\nwill indicate the desired name of the output file where the output stream will be written to. A random name will\nbe applied for the file of this output unless otherwise specified.\n",
+        "type": "string",
+        "enum": [
+          "stdout"
+        ],
+        "title": "CWLOutputStdOutDefinition"
+      },
+      "cwl-CWLOutputStdOutObjectType": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/cwl-CWLOutputStdOutDefinition"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "CWLOutputStdOutObjectType"
+      },
+      "cwl-CWLOutputStdErrDefinition": {
+        "description": "Indicates that the data pushed to the standard error stream by the command will be redirected to this CWL output.\nCan be defined for only one output. If combined with 'stderr' at the root of the CWL document, that definition\nwill indicate the desired name of the output file where the error stream will be written to.  A random name will\nbe applied for the file of this output unless otherwise specified.\n",
+        "type": "string",
+        "enum": [
+          "stderr"
+        ],
+        "title": "CWLOutputStdErrDefinition"
+      },
+      "cwl-CWLOutputStdErrObjectType": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/cwl-CWLOutputStdErrDefinition"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "CWLOutputStdErrObjectType"
+      },
+      "cwl-CWLTypeRecordFieldDef": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLTypeRecordFieldDefBase"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLFileOnlyParametersConditional"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLDirectoryOnlyParametersConditional"
+          }
+        ],
+        "title": "CWLTypeRecordFieldDef"
+      },
+      "cwl-CWLDefault": {
+        "title": "CWLDefault",
+        "description": "Default value of input if not provided for task execution.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-AnyLiteralType"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-AnyLiteralList"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLDefaultLocation"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLDefaultObject"
+          },
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/cwl-CWLDefaultObject"
+            }
+          }
+        ]
+      },
+      "cwl-AnyLiteralType": {
+        "oneOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "title": "AnyLiteralType"
+      },
+      "cwl-AnyLiteralList": {
+        "type": "array",
+        "title": "AnyLiteralList",
+        "items": {
+          "$ref": "#/components/schemas/cwl-AnyLiteralType"
+        }
+      },
+      "cwl-CWLDefaultLocation": {
+        "type": "object",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "File",
+              "Directory"
+            ]
+          },
+          "path": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "basename": {
+            "type": "string"
+          },
+          "nameroot": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "class"
+        ],
+        "oneOf": [
+          {
+            "required": [
+              "path"
+            ]
+          },
+          {
+            "required": [
+              "location"
+            ]
+          }
+        ],
+        "additionalProperties": false,
+        "title": "CWLDefaultLocation"
+      },
+      "cwl-CWLDefaultObject": {
+        "type": "object",
+        "not": {
+          "description": "Avoid false-positive match of default File or Directory location definition.",
+          "properties": {
+            "class": {
+              "type": "string",
+              "enum": [
+                "File",
+                "Directory"
+              ]
+            }
+          }
+        },
+        "title": "CWLDefaultObject"
+      },
+      "cwl-CWLTypeRecordFields": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLTypeRecordFieldsMap"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLTypeRecordFieldsList"
+          }
+        ],
+        "title": "CWLTypeRecordFields"
+      },
+      "cwl-CWLImport": {
+        "title": "CWLImport",
+        "description": "The schema validation of the CWL will not itself perform the '$import' to resolve and validate its contents.\nTherefore, the complete schema will not be validated entirely, and could still be partially malformed.\nTo ensure proper and exhaustive validation of a CWL definition with this schema, all '$import' directives\nshould be resolved and extended beforehand.\nRepresents an '$import' directive that should point toward another compatible CWL file to import where specified.\nThe contents of the imported file should be relevant contextually where it is being imported.\n",
+        "type": "object",
+        "properties": {
+          "$import": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$import"
+        ],
+        "additionalProperties": false
+      },
+      "cwl-CWLVersion": {
+        "type": "object",
+        "properties": {
+          "cwlVersion": {
+            "type": "string",
+            "title": "cwlVersion",
+            "description": "CWL version of the described application package.",
+            "pattern": "^v\\d+(\\.\\d+(\\.\\d+)*)*$"
+          }
+        },
+        "required": [
+          "cwlVersion"
+        ],
+        "title": "CWLVersion"
+      },
+      "cwl-CWLMetadata": {
+        "type": "object",
+        "properties": {
+          "s:keywords": {
+            "$ref": "#/components/schemas/cwl-CWLKeywordList"
+          },
+          "version": {
+            "type": "string",
+            "title": "version",
+            "description": "Version of the process.",
+            "example": "1.2.3",
+            "pattern": "^\\d+(\\.\\d+(\\.\\d+(\\.[A-Za-z0-9\\-_]+)*)*)*$"
+          }
+        },
+        "title": "CWLMetadata"
+      },
+      "cwl-CWLDocumentation": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "doc": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "title": "CWLDocumentation"
+      },
+      "cwl-CWLAtomicBase": {
+        "type": "object",
+        "title": "CWL atomic definition",
+        "description": "Direct CWL definition instead of the graph representation.",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/cwl-CWLIdentifier"
+          },
+          "class": {
+            "type": "string",
+            "title": "Class",
+            "description": "CWL class specification. This is used to differentiate between single Application Package (AP)definitions and Workflow that chains multiple packages.",
+            "enum": [
+              "CommandLineTool",
+              "ExpressionTool"
+            ]
+          },
+          "intent": {
+            "$ref": "#/components/schemas/cwl-CWLIntent"
+          },
+          "requirements": {
+            "$ref": "#/components/schemas/cwl-CWLRequirements"
+          },
+          "hints": {
+            "$ref": "#/components/schemas/cwl-CWLHints"
+          },
+          "baseCommand": {
+            "$ref": "#/components/schemas/cwl-CWLCommand"
+          },
+          "arguments": {
+            "$ref": "#/components/schemas/cwl-CWLArguments"
+          },
+          "inputs": {
+            "$ref": "#/components/schemas/cwl-CWLInputsDefinition"
+          },
+          "outputs": {
+            "$ref": "#/components/schemas/cwl-CWLOutputsDefinition"
+          },
+          "stdin": {
+            "description": "Source of the input stream.\nTypically, an expression referring to an existing file name or an input of the CWL document.\n",
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          },
+          "stdout": {
+            "description": "Destination of the output stream.\nTypically, an expression referring to a desired file name or provided by a CWL input reference.\n",
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          },
+          "stderr": {
+            "description": "Destination of the error stream.\nTypically, an expression referring to a desired file name or provided by a CWL input reference.\n",
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          },
+          "scatter": {
+            "$ref": "#/components/schemas/cwl-CWLScatter"
+          },
+          "scatterMethod": {
+            "$ref": "#/components/schemas/cwl-CWLScatterMethod"
+          }
+        },
+        "required": [
+          "class",
+          "inputs",
+          "outputs"
+        ]
+      },
+      "cwl-CWLOutputList": {
+        "type": "array",
+        "title": "CWLOutputList",
+        "description": "Package outputs defined as items.",
+        "items": {
+          "$ref": "#/components/schemas/cwl-CWLOutputItem"
+        }
+      },
+      "cwl-CWLOutputMap": {
+        "type": "object",
+        "title": "CWLOutputMap",
+        "description": "Package outputs defined as mapping.",
+        "additionalProperties": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/cwl-CWLType"
+            },
+            {
+              "$ref": "#/components/schemas/cwl-CWLOutputObject"
+            },
+            {
+              "$ref": "#/components/schemas/cwl-CWLOutputStdOut"
+            },
+            {
+              "$ref": "#/components/schemas/cwl-CWLOutputStdErr"
+            },
+            {
+              "$ref": "#/components/schemas/cwl-CWLImport"
+            }
+          ]
+        }
+      },
+      "cwl-CWLOutputItem": {
+        "type": "object",
+        "title": "CWLOutputItem",
+        "description": "Output specification. Note that multiple formats are supported\nand not all specification variants or parameters are presented here. Please\nrefer to official CWL documentation for more details (https://www.commonwl.org).\n",
+        "properties": {
+          "type": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/cwl-CWLType"
+              },
+              {
+                "$ref": "#/components/schemas/cwl-CWLOutputStdOut"
+              },
+              {
+                "$ref": "#/components/schemas/cwl-CWLOutputStdErr"
+              }
+            ]
+          },
+          "outputBinding": {
+            "$ref": "#/components/schemas/cwl-OutputBinding"
+          },
+          "id": {
+            "description": "Identifier of the CWL output.",
+            "$ref": "#/components/schemas/cwl-CWLIdentifier"
+          }
+        },
+        "required": [
+          "type",
+          "id"
+        ]
+      },
+      "cwl-CWLWorkflowStepObject": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepDefinition"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepScatter"
+          }
+        ],
+        "title": "CWLWorkflowStepObject"
+      },
+      "cwl-CWLInputStdInDefinition": {
+        "description": "Indicates that the value passed to this CWL input will be redirected to the standard input stream of the command.\nCan be defined for only one input and must not be combined with 'stdin' at the root of the CWL document.\n",
+        "type": "string",
+        "enum": [
+          "stdin"
+        ],
+        "title": "CWLInputStdInDefinition"
+      },
+      "cwl-CWLInputStdInObjectType": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/cwl-CWLInputStdInDefinition"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "CWLInputStdInObjectType"
+      },
+      "cwl-CWLInputStdIn": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLInputStdInDefinition"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLInputStdInObjectType"
+          }
+        ],
+        "title": "CWLInputStdIn"
+      },
+      "cwl-CWLArguments": {
+        "type": "array",
+        "title": "CWLArguments",
+        "description": "Base arguments passed to the command.",
+        "items": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/components/schemas/cwl-InputBinding"
+            }
+          ]
+        }
+      },
+      "cwl-SoftwarePackage": {
+        "type": "object",
+        "properties": {
+          "package": {
+            "type": "string"
+          },
+          "version": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "specs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/cwl-ReferenceURL"
+            }
+          }
+        },
+        "required": [
+          "package"
+        ],
+        "additionalProperties": false,
+        "title": "SoftwarePackage"
+      },
+      "cwl-SoftwarePackageSpecs": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "title": "SoftwarePackageSpecs"
       },
       "dynamic-enumeration": {
         "type": "object",
@@ -3002,7 +5331,8 @@
               "type": "string"
             }
           }
-        }
+        },
+        "title": "enumeration"
       },
       "processes-core-processSummary": {
         "allOf": [
@@ -3036,7 +5366,8 @@
               }
             }
           }
-        ]
+        ],
+        "title": "processSummary"
       },
       "processes-core-process": {
         "allOf": [
@@ -3058,7 +5389,8 @@
               }
             }
           }
-        ]
+        ],
+        "title": "process"
       },
       "processes-core-processList": {
         "type": "object",
@@ -3079,7 +5411,8 @@
               "$ref": "#/components/schemas/processes-core-link"
             }
           }
-        }
+        },
+        "title": "processList"
       },
       "processes-core-jobList": {
         "type": "object",
@@ -3100,7 +5433,8 @@
               "$ref": "#/components/schemas/processes-core-link"
             }
           }
-        }
+        },
+        "title": "jobList"
       },
       "processes-core-descriptionType": {
         "type": "object",
@@ -3123,10 +5457,12 @@
               "$ref": "#/components/schemas/processes-core-metadata"
             }
           }
-        }
+        },
+        "title": "descriptionType"
       },
       "processes-core-binaryValue": {
-        "type": "string"
+        "type": "string",
+        "title": "binaryValue"
       },
       "processes-workflows-inputParameterized": {
         "allOf": [
@@ -3144,7 +5480,8 @@
           {
             "$ref": "#/components/schemas/processes-core-fieldsModifiers"
           }
-        ]
+        ],
+        "title": "inputParameterized"
       },
       "processes-core-format": {
         "type": "object",
@@ -3166,7 +5503,8 @@
               }
             ]
           }
-        }
+        },
+        "title": "format"
       },
       "processes-core-schemaAndOccurrences": {
         "type": "object",
@@ -3195,7 +5533,8 @@
               }
             ]
           }
-        }
+        },
+        "title": "schemaAndOccurrences"
       },
       "processes-core-inputDescription": {
         "allOf": [
@@ -3233,7 +5572,8 @@
               }
             }
           }
-        ]
+        ],
+        "title": "inputDescription"
       },
       "processes-core-value": {
         "anyOf": [
@@ -3243,7 +5583,8 @@
           {
             "type": "object"
           }
-        ]
+        ],
+        "title": "value"
       },
       "processes-core-collectionValue": {
         "allOf": [
@@ -3426,7 +5767,8 @@
               }
             }
           }
-        ]
+        ],
+        "title": "collectionValue"
       },
       "processes-core-valueNoObject": {
         "anyOf": [
@@ -3455,7 +5797,8 @@
           {
             "$ref": "#/components/schemas/processes-core-collectionValue"
           }
-        ]
+        ],
+        "title": "valueNoObject"
       },
       "processes-workflows-valueNoObject-workflows": {
         "anyOf": [
@@ -3490,7 +5833,8 @@
           {
             "$ref": "#/components/schemas/processes-workflows-inputParameterized"
           }
-        ]
+        ],
+        "title": "valueNoObject-workflows"
       },
       "processes-core-jobControlOptions": {
         "type": "string",
@@ -3498,7 +5842,8 @@
           "sync-execute",
           "async-execute",
           "dismiss"
-        ]
+        ],
+        "title": "jobControlOptions"
       },
       "processes-core-metadata": {
         "oneOf": [
@@ -3541,7 +5886,8 @@
               }
             }
           }
-        ]
+        ],
+        "title": "metadata"
       },
       "processes-core-values": {
         "anyOf": [
@@ -3554,7 +5900,8 @@
               "$ref": "#/components/schemas/processes-core-inlineOrRefValue"
             }
           }
-        ]
+        ],
+        "title": "values"
       },
       "processes-workflows-values-workflows": {
         "oneOf": [
@@ -3567,7 +5914,8 @@
               "$ref": "#/components/schemas/processes-workflows-inlineOrRefValue-workflows"
             }
           }
-        ]
+        ],
+        "title": "values-workflows"
       },
       "processes-core-outputSelection": {
         "type": "object",
@@ -3575,7 +5923,8 @@
           "format": {
             "$ref": "#/components/schemas/processes-core-format"
           }
-        }
+        },
+        "title": "outputSelection"
       },
       "processes-core-outputDescription": {
         "allOf": [
@@ -3591,7 +5940,8 @@
           {
             "$ref": "#/components/schemas/processes-core-schemaAndOccurrences"
           }
-        ]
+        ],
+        "title": "outputDescription"
       },
       "processes-core-qualifiedValue": {
         "allOf": [
@@ -3609,7 +5959,8 @@
               }
             }
           }
-        ]
+        ],
+        "title": "qualifiedValue"
       },
       "processes-core-reference": {
         "type": "object",
@@ -3622,13 +5973,15 @@
             "format": "uri-reference"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "title": "reference"
       },
       "processes-core-results": {
         "type": "object",
         "additionalProperties": {
           "$ref": "#/components/schemas/processes-core-values"
-        }
+        },
+        "title": "results"
       },
       "processes-core-schema": {
         "description": "Attributes of the features or fields of a coverage range. Defined by a subset of the JSON Schema for the properties of a feature",
@@ -3725,7 +6078,8 @@
               }
             }
           }
-        }
+        },
+        "title": "schema"
       },
       "processes-core-statusCode": {
         "type": "string",
@@ -3736,7 +6090,8 @@
           "successful",
           "failed",
           "dismissed"
-        ]
+        ],
+        "title": "statusCode"
       },
       "processes-core-subscriber": {
         "description": "Optional URIs for callbacks for this job.\n\nSupport for this parameter is not required and the parameter may be\nremoved from the API definition, if conformance class **'callback'**\nis not listed in the conformance declaration under `/conformance`.",
@@ -3754,7 +6109,8 @@
             "type": "string",
             "format": "uri"
           }
-        }
+        },
+        "title": "subscriber"
       },
       "processes-core-inlineOrRefValue": {
         "oneOf": [
@@ -3767,7 +6123,8 @@
           {
             "$ref": "#/components/schemas/processes-core-link"
           }
-        ]
+        ],
+        "title": "inlineOrRefValue"
       },
       "processes-workflows-inlineOrRefValue-workflows": {
         "oneOf": [
@@ -3780,7 +6137,8 @@
           {
             "$ref": "#/components/schemas/common-core-link"
           }
-        ]
+        ],
+        "title": "inlineOrRefValue-workflows"
       },
       "processes-core-fieldsModifiers": {
         "type": "object",
@@ -3825,7 +6183,8 @@
               "type": "string"
             }
           }
-        }
+        },
+        "title": "fieldsModifiers"
       },
       "processes-core-statusInfo": {
         "allOf": [
@@ -3918,7 +6277,8 @@
               }
             }
           }
-        ]
+        ],
+        "title": "statusInfo"
       },
       "processes-core-dataAccessAPIs": {
         "type": "object",
@@ -3929,7 +6289,8 @@
               "$ref": "#/components/schemas/processes-core-apis"
             }
           }
-        }
+        },
+        "title": "dataAccessAPIs"
       },
       "processes-core-apis": {
         "description": "A non-exhaustive list of OGC and other data access APIs.  This list can\nbe extended as required.",
@@ -3944,7 +6305,8 @@
           "ogc-api-records",
           "ogc-api-dggs",
           "stac-api"
-        ]
+        ],
+        "title": "apis"
       },
       "processes-core-dataClasses": {
         "type": "object",
@@ -3956,7 +6318,8 @@
               "format": "uri"
             }
           }
-        }
+        },
+        "title": "dataClasses"
       },
       "processes-dru-ogcapppkg": {
         "type": "object",
@@ -3978,7 +6341,8 @@
           "executionUnit": {
             "$ref": "#/components/schemas/processes-dru-executionUnit"
           }
-        }
+        },
+        "title": "ogcapppkg"
       },
       "processes-dru-staticIndicator": {
         "allOf": [
@@ -3994,7 +6358,8 @@
               }
             }
           }
-        ]
+        ],
+        "title": "staticIndicator"
       },
       "processes-core-linkBase": {
         "type": "object",
@@ -4017,7 +6382,8 @@
           "length": {
             "type": "integer"
           }
-        }
+        },
+        "title": "linkBase"
       },
       "processes-core-linkBaseExtended": {
         "type": "object",
@@ -4038,7 +6404,8 @@
               "type": "string"
             }
           }
-        }
+        },
+        "title": "linkBaseExtended"
       },
       "processes-core-link": {
         "allOf": [
@@ -4059,7 +6426,8 @@
               }
             }
           }
-        ]
+        ],
+        "title": "link"
       },
       "processes-core-executionUnitRequirements": {
         "type": "object",
@@ -4079,7 +6447,8 @@
               }
             }
           }
-        }
+        },
+        "title": "executionUnitRequirements"
       },
       "processes-core-bbox-def-crs": {
         "anyOf": [
@@ -4097,7 +6466,8 @@
             "format": "uri",
             "default": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
           }
-        ]
+        ],
+        "title": "bbox-def-crs"
       },
       "processes-core-bbox": {
         "type": "object",
@@ -4124,7 +6494,8 @@
           "crs": {
             "$ref": "#/components/schemas/processes-core-bbox-def-crs"
           }
-        }
+        },
+        "title": "bbox"
       },
       "cql2-cql2": {
         "oneOf": [
@@ -4152,7 +6523,8 @@
           {
             "type": "boolean"
           }
-        ]
+        ],
+        "title": "cql2"
       },
       "cql2-cql2-definitions": {
         "type": "object",
@@ -4173,7 +6545,8 @@
           "args": {
             "$ref": "#/components/schemas/cql2-cql2-definitions"
           }
-        }
+        },
+        "title": "cql2-definitions"
       },
       "processes-dru-inputBinding": {
         "type": "object",
@@ -4207,7 +6580,8 @@
             "type": "boolean"
           }
         },
-        "additionalProperties": true
+        "additionalProperties": true,
+        "title": "inputBinding"
       },
       "processes-dru-outputBinding": {
         "type": "object",
@@ -4228,7 +6602,8 @@
             ]
           }
         },
-        "additionalProperties": true
+        "additionalProperties": true,
+        "title": "outputBinding"
       },
       "processes-dru-executionUnitContainer": {
         "type": "object",
@@ -4307,7 +6682,780 @@
             }
           }
         },
-        "additionalProperties": true
+        "additionalProperties": true,
+        "title": "executionUnitContainer"
+      },
+      "cwl-CWLKeywordList": {
+        "title": "KeywordList",
+        "type": "array",
+        "description": "Keywords applied to the process for search and categorization purposes.",
+        "items": {
+          "type": "string",
+          "title": "keyword",
+          "minLength": 1
+        }
+      },
+      "cwl-CWLTextPatternID": {
+        "description": "Identifier with text pattern that can allow additional non-ASCII characters depending on regex implementation.\nThe identifier allows a '#' or a relative 'sub/part#ref' prefix, to support references to other definitions\nin the CWL document, such as when using 'SchemaDefRequirement'.\n\nJSON spec regex does not include '\\w' in its default subset to allow all word-like unicode characters\n(see reference: https://json-schema.org/understanding-json-schema/reference/regular_expressions.html).\n\nSince support is implementation specific, add both the ASCII-only and '\\w' representation simultaneously\nand let the parser reading this document apply whichever is more relevant or supported\n(see discussion: https://github.com/common-workflow-language/cwl-v1.2/pull/256#discussion_r1234037814).\n",
+        "pattern": "^([A-Za-z0-9\\w]+(/[A-Za-z0-9\\w]+)*)?[#.]?[A-Za-z0-9\\w]+(?:[-_.][A-Za-z0-9\\w]+)*$",
+        "type": "string",
+        "title": "Generic identifier name pattern."
+      },
+      "cwl-CWLIdentifier": {
+        "anyOf": [
+          {
+            "type": "string",
+            "title": "UUID",
+            "description": "Unique identifier.",
+            "format": "uuid",
+            "pattern": "^[a-f0-9]{8}(?:-?[a-f0-9]{4}){3}-?[a-f0-9]{12}$"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLTextPatternID"
+          }
+        ],
+        "title": "CWLIdentifier",
+        "description": "Reference to the process identifier."
+      },
+      "cwl-CWLIntent": {
+        "type": "array",
+        "title": "CWLIntent",
+        "items": {
+          "type": "string",
+          "title": "item",
+          "description": "Identifier URL to a concept for the type of computational operation accomplished by this process\n(see example operations: http://edamontology.org/operation_0004).\n",
+          "format": "url",
+          "pattern": "^((?:http|ftp)s?://)?(?!.*//.*$)(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)+(?:[A-Za-z]{2,6}\\.?|[A-Za-z0-9-]{2,}\\.?)|localhost|\\[[a-f0-9:]+\\]|\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})(?::\\d+)?(?:/?|[/?]\\S+)$"
+        }
+      },
+      "cwl-CUDAComputeCapabilityArray": {
+        "type": "array",
+        "title": "CUDAComputeCapabilityArray",
+        "items": {
+          "type": "string",
+          "title": "CUDA compute capability",
+          "description": "The compute capability supported by the GPU hardware.",
+          "pattern": "^\\d+\\.\\d+$"
+        },
+        "minItems": 1
+      },
+      "cwl-CUDAComputeCapability": {
+        "oneOf": [
+          {
+            "type": "string",
+            "title": "CUDA compute capability",
+            "description": "The compute capability supported by the GPU hardware.",
+            "pattern": "^\\d+\\.\\d+$"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CUDAComputeCapabilityArray"
+          }
+        ],
+        "title": "CUDA compute capability",
+        "description": "The compute capability supported by the GPU hardware.\n\n* If this is a single value, it defines only the minimum compute capability.\n  GPUs with higher capability are also accepted.\n* If it is an array value, then only select GPUs with compute capabilities that explicitly\n  appear in the array.\n  See https://docs.nvidia.com/deploy/cuda-compatibility/#faq and\n  https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html#cuda-compute-capability\n  for details.\n"
+      },
+      "cwl-ReferenceURL": {
+        "type": "string",
+        "format": "url",
+        "pattern": "^((?:http|ftp)s?:\\/\\/)?(?!.*\\/\\/.*$)(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)+(?:[A-Za-z]{2,6}\\.?|[A-Za-z0-9-]{2,}\\.?)|localhost|\\[[a-f0-9:]+\\]|\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})(?::\\d+)?(?:\\/?|[/?]\\S+)$",
+        "title": "ReferenceURL"
+      },
+      "cwl-CWLTypeSymbolValues": {
+        "oneOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "title": "CWLTypeSymbolValues"
+      },
+      "cwl-CWLTypeSymbols": {
+        "type": "array",
+        "title": "CWLTypeSymbols (Allowed values composing the enum).",
+        "items": {
+          "$ref": "#/components/schemas/cwl-CWLTypeSymbolValues"
+        }
+      },
+      "cwl-CWLTypeRecordRefPattern": {
+        "type": "string",
+        "format": "url",
+        "pattern": "^(((?:http|ftp)s?:\\/\\/)?(?!.*\\/\\/.*$)(?:(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\\.)+(?:[A-Za-z]{2,6}\\.?|[A-Za-z0-9-]{2,}\\.?)|localhost|\\[[a-f0-9:]+\\]|\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3})(?::\\d+)?(?:\\/?|[\\/?]\\S+))?(?:[A-Za-z0-9\\w\\-.\\/]+)?\\#?[A-Za-z0-9\\w\\-.]+$",
+        "title": "CWLTypeRecordRefPattern"
+      },
+      "cwl-CWLFormat": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          },
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/cwl-CWLExpression"
+            }
+          }
+        ],
+        "title": "CWLFormat"
+      },
+      "cwl-LoadListingEnum": {
+        "type": "string",
+        "title": "LoadListingEnum",
+        "enum": [
+          "no_listing",
+          "shallow_listing",
+          "deep_listing"
+        ]
+      },
+      "cwl-CWLDirectoryOnlyParameters": {
+        "type": "object",
+        "properties": {
+          "loadListing": {
+            "$ref": "#/components/schemas/cwl-LoadListingEnum"
+          }
+        },
+        "title": "CWLDirectoryOnlyParameters"
+      },
+      "cwl-CWLTypeRecordFieldsItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLTypeRecordFieldDef"
+          },
+          {
+            "required": [
+              "name"
+            ]
+          }
+        ],
+        "title": "CWLTypeRecordFieldsItem"
+      },
+      "cwl-Checksum": {
+        "description": "Minimal pattern check to know which hash algorithm to apply,\nbut don't check too harshly for the rest (length, allowed characters, etc.).\n",
+        "type": "string",
+        "pattern": "^[a-z0-9\\-]+\\$[\\w\\-.]+$",
+        "title": "Checksum"
+      },
+      "cwl-InlineJavascriptLibObject": {
+        "type": "object",
+        "properties": {
+          "$include": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "$include"
+        ],
+        "additionalProperties": false,
+        "title": "InlineJavascriptLibObject"
+      },
+      "cwl-InlineJavascriptLibItem": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-InlineJavascriptLibObject"
+          }
+        ],
+        "title": "InlineJavascriptLibItem"
+      },
+      "cwl-InlineJavascriptLibraries": {
+        "type": "array",
+        "title": "InlineJavascriptLibraries",
+        "description": "Additional code fragments that will also be inserted before executing the expression code.\nAllows for function definitions that may be called from CWL expressions.\n",
+        "items": {
+          "title": "exp_lib",
+          "$ref": "#/components/schemas/cwl-InlineJavascriptLibItem"
+        }
+      },
+      "cwl-ResourceCoresMinimum": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-ResourceQuantityOrFractional"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          }
+        ],
+        "title": "ResourceCoresMinimum (Minimum reserved number of CPU cores).",
+        "description": "Minimum reserved number of CPU cores.\n\nMay be a fractional value to indicate to a scheduling algorithm that one core can be allocated to\nmultiple jobs. For example, a value of 0.25 indicates that up to 4 jobs\nmay run in parallel on 1 core. A value of 1.25 means that up to 3 jobs\ncan run on a 4 core system (4/1.25 ~ 3).\n\nProcesses can only share a core allocation if the sum of each of their 'ramMax', 'tmpdirMax', and\n'outdirMax' requests also do not exceed the capacity of the node.\n\nProcesses sharing a core must have the same level of isolation (typically a container\nor VM) that they would normally have.\n\nThe reported number of CPU cores reserved for the process, which is available to expressions\non the 'CommandLineTool' as 'runtime.cores', must be a non-zero integer, and may be calculated by\nrounding up the cores request to the next whole number.\n\nScheduling systems may allocate fractional CPU resources by setting quotas or scheduling weights.\nScheduling systems that do not support fractional CPUs may round up the request to the next whole number.\n",
+        "default": 1
+      },
+      "cwl-ResourceCoresMaximum": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-ResourceQuantityOrFractional"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          }
+        ],
+        "title": "ResourceCoresMaximum (Maximum reserved number of CPU cores).",
+        "description": "Maximum reserved number of CPU cores.\nSee 'coresMin' for discussion about fractional CPU requests.\n"
+      },
+      "cwl-ResourceRAMMinimum": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-ResourceQuantityOrFractional"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          }
+        ],
+        "title": "ResourceRAMMinimum (Minimum reserved RAM in mebibytes).",
+        "description": "Minimum reserved RAM in mebibytes (2**20).\n\nMay be a fractional value. If so, the actual RAM request must be rounded up\nto the next whole number.\n\nThe reported amount of RAM reserved for the process, which is available to\nexpressions on the 'CommandLineTool' as 'runtime.ram', must be a non-zero integer.\n",
+        "default": 256
+      },
+      "cwl-ResourceRAMMaximum": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-ResourceQuantityOrFractional"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          }
+        ],
+        "title": "ResourceRAMMaximum (Maximum reserved RAM in mebibytes).",
+        "description": "Maximum reserved RAM in mebibytes (2**20).\nSee 'ramMin' for discussion about fractional RAM requests.\n"
+      },
+      "cwl-ResourceTmpDirMinimum": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-ResourceQuantityOrFractional"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          }
+        ],
+        "title": "ResourceTmpDirMinimum (Minimum reserved filesystem based storage for the designated temporary) directory in mebibytes.",
+        "description": "Minimum reserved filesystem based storage for the designated temporary\ndirectory in mebibytes (2**20).\n\nMay be a fractional value. If so, the actual storage request must be rounded\nup to the next whole number.\n\nThe reported amount of storage reserved for the process, which is available\nto expressions on the 'CommandLineTool' as 'runtime.tmpdirSize', must be a non-zero integer.\n",
+        "default": 1024
+      },
+      "cwl-ResourceTmpDirMaximum": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-ResourceQuantityOrFractional"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          }
+        ],
+        "title": "ResourceTmpDirMaximum (Maximum reserved filesystem based storage for the designated temporary directory in mebibytes).",
+        "description": "Maximum reserved filesystem based storage for the designated temporary directory in mebibytes (2**20).\nSee 'tmpdirMin' for discussion about fractional storage requests.\n"
+      },
+      "cwl-ResourceOutDirMinimum": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-ResourceQuantityOrFractional"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          }
+        ],
+        "title": "ResourceOutDirMinimum (Minimum reserved filesystem based storage for the designated output directory in mebibytes).",
+        "description": "Minimum reserved filesystem based storage for the designated output\ndirectory in mebibytes (2**20).\n\nMay be a fractional value. If so, the actual storage request must be rounded\nup to the next whole number.\n\nThe reported amount of storage reserved for the process, which is available\nto expressions on the 'CommandLineTool' as 'runtime.outdirSize', must be a non-zero integer.\n",
+        "default": 1024
+      },
+      "cwl-ResourceOutDirMaximum": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-ResourceQuantityOrFractional"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          }
+        ],
+        "title": "ResourceOutDirMaximum (Maximum reserved filesystem based storage for the designated output directory in mebibytes).",
+        "description": "Maximum reserved filesystem based storage for the designated output\ndirectory in mebibytes (2**20).\nSee 'outdirMin' for discussion about fractional storage requests.\n",
+        "default": 1
+      },
+      "cwl-TimeLimitValue": {
+        "oneOf": [
+          {
+            "type": "number",
+            "minimum": 0
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          }
+        ],
+        "title": "TimeLimitValue",
+        "description": "The time limit, in seconds.\n\nA time limit of zero means no time limit.\nNegative time limits are an error.\n"
+      },
+      "cwl-EnableReuseValue": {
+        "oneOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLExpression"
+          }
+        ],
+        "title": "EnableReuseValue",
+        "description": "Indicates if reuse is enabled for this tool.\n\nCan be an expression when combined with 'InlineJavascriptRequirement'\n(see also: https://www.commonwl.org/v1.2/CommandLineTool.html#Expression).\n"
+      },
+      "cwl-BuiltinRequirement": {
+        "type": "object",
+        "title": "BuiltinRequirement",
+        "description": "Hint indicating that the Application Package corresponds to a\nbuiltin process of this instance. (note: can only be an 'hint'\nas it is unofficial CWL specification).\n",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "BuiltinRequirement"
+            ]
+          },
+          "process": {
+            "description": "Builtin process identifier.",
+            "$ref": "#/components/schemas/cwl-CWLTextPatternID"
+          }
+        },
+        "required": [
+          "process",
+          "class"
+        ],
+        "additionalProperties": false
+      },
+      "cwl-OGCAPIRequirement": {
+        "type": "object",
+        "title": "OGCAPIRequirement",
+        "description": "Hint indicating that the Application Package corresponds to an\nOGC API - Processes provider that should be remotely executed and monitored\nby this instance. (note: can only be an 'hint' as it is unofficial CWL specification).\n",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "OGCAPIRequirement"
+            ]
+          },
+          "process": {
+            "description": "Process location.",
+            "$ref": "#/components/schemas/cwl-ReferenceURL"
+          }
+        },
+        "required": [
+          "process"
+        ],
+        "additionalProperties": false
+      },
+      "cwl-WPS1Requirement": {
+        "type": "object",
+        "title": "WPS1Requirement",
+        "description": "Hint indicating that the Application Package corresponds to a\nWPS-1 provider process that should be remotely executed and monitored by this\ninstance. (note: can only be an ''hint'' as it is unofficial CWL specification).\n",
+        "properties": {
+          "class": {
+            "type": "string",
+            "enum": [
+              "WPS1Requirement"
+            ]
+          },
+          "process": {
+            "description": "Process identifier of the remote WPS provider.",
+            "$ref": "#/components/schemas/cwl-CWLTextPatternID"
+          },
+          "provider": {
+            "description": "WPS provider endpoint.",
+            "$ref": "#/components/schemas/cwl-ReferenceURL"
+          }
+        },
+        "required": [
+          "process",
+          "provider"
+        ],
+        "additionalProperties": false
+      },
+      "cwl-UnknownRequirement": {
+        "type": "object",
+        "description": "Generic schema to allow alternative CWL requirements/hints not explicitly defined in schemas.",
+        "properties": {
+          "class": {
+            "type": "string",
+            "title": "Requirement Class Identifier",
+            "description": "CWL requirement class specification.",
+            "example": "UnknownRequirement",
+            "not": {
+              "enum": [
+                "cwltool:CUDARequirement",
+                "DockerRequirement",
+                "SoftwareRequirement",
+                "ShellCommandRequirement",
+                "EnvVarRequirement",
+                "SchemaDefRequirement",
+                "InitialWorkDirRequirement",
+                "InlineJavascriptRequirement",
+                "InplaceUpdateRequirement",
+                "LoadListingRequirement",
+                "NetworkAccess",
+                "ResourceRequirement",
+                "ScatterFeatureRequirement",
+                "ToolTimeLimit",
+                "WorkReuse",
+                "MultipleInputFeatureRequirement",
+                "StepInputExpressionRequirement",
+                "SubworkflowFeatureRequirement"
+              ]
+            }
+          }
+        },
+        "title": "UnknownRequirement"
+      },
+      "cwl-CWLHintsMapExtras": {
+        "type": "object",
+        "properties": {
+          "BuiltinRequirement": {
+            "$ref": "#/components/schemas/cwl-BuiltinRequirement"
+          },
+          "OGCAPIRequirement": {
+            "$ref": "#/components/schemas/cwl-OGCAPIRequirement"
+          },
+          "WPS1Requirement": {
+            "$ref": "#/components/schemas/cwl-WPS1Requirement"
+          }
+        },
+        "additionalProperties": {
+          "$ref": "#/components/schemas/cwl-UnknownRequirement"
+        },
+        "title": "CWLHintsMapExtras"
+      },
+      "cwl-CWLHintsItemExtras": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-BuiltinRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-OGCAPIRequirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-WPS1Requirement"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-UnknownRequirement"
+          }
+        ],
+        "title": "CWLHintsItemExtras"
+      },
+      "cwl-CWLHintsItem": {
+        "title": "CWLHintsItem",
+        "description": "For any new items added, ensure they are added under 'class' of 'UnknownRequirement' as well.\nOtherwise, insufficiently restrictive classes could cause multiple matches, failing the 'oneOf' condition.\n",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLRequirementsItem"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLHintsItemExtras"
+          }
+        ]
+      },
+      "cwl-CommandParts": {
+        "type": "array",
+        "title": "Command Parts",
+        "items": {
+          "type": "string",
+          "title": "cmd"
+        },
+        "additionalProperties": false
+      },
+      "cwl-CWLInputItemBase": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/cwl-CWLType"
+              },
+              {
+                "$ref": "#/components/schemas/cwl-CWLInputStdIn"
+              }
+            ]
+          },
+          "inputBinding": {
+            "$ref": "#/components/schemas/cwl-InputBinding"
+          },
+          "id": {
+            "description": "Identifier of the CWL input.",
+            "$ref": "#/components/schemas/cwl-CWLIdentifier"
+          }
+        },
+        "required": [
+          "type",
+          "id"
+        ],
+        "additionalProperties": {},
+        "title": "CWLInputItemBase"
+      },
+      "cwl-CWLInputObjectBase": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/cwl-CWLType"
+          },
+          "inputBinding": {
+            "$ref": "#/components/schemas/cwl-InputBinding"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "additionalProperties": {},
+        "title": "CWLInputObjectBase"
+      },
+      "cwl-CWLInputObject": {
+        "title": "CWLInputObject (CWL type definition with parameters).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLInputObjectBase"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLDefaultTypedConditional"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLDocumentation"
+          }
+        ]
+      },
+      "cwl-OutputBinding": {
+        "type": "object",
+        "title": "OutputBinding",
+        "description": "Defines how to retrieve the output result from the command.",
+        "properties": {
+          "glob": {
+            "description": "Glob pattern to find the output on disk or mounted docker volume.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/cwl-CWLExpression"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/cwl-CWLExpression"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "cwl-CWLOutputObjectBase": {
+        "type": "object",
+        "title": "CWLOutputObject (CWL type definition with parameters).",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/cwl-CWLType"
+          },
+          "outputBinding": {
+            "$ref": "#/components/schemas/cwl-OutputBinding"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "cwl-CWLScatterMulti": {
+        "type": "array",
+        "title": "CWLScatterMulti",
+        "items": {
+          "$ref": "#/components/schemas/cwl-CWLIdentifier"
+        }
+      },
+      "cwl-CWLScatter": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLIdentifier"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLScatterMulti"
+          }
+        ],
+        "title": "CWLScatter",
+        "description": "One or more input identifier of an application step within a Workflow\nwere an array-based input to that Workflow should be scattered across multiple\ninstances of the step application.\n"
+      },
+      "cwl-CWLScatterMethod": {
+        "type": "string",
+        "title": "scatterMethod",
+        "description": "Describes how to decompose the scattered input into a discrete\nset of jobs. When 'dotproduct', specifies that each of the input arrays\nare aligned and one element taken from each array to construct each job.\nIt is an error if all input arrays are of different length. When 'nested_crossproduct',\nspecifies the Cartesian product of the inputs, producing a job for every\ncombination of the scattered inputs. The output must be nested arrays\nfor each level of scattering, in the order that the input arrays are listed\nin the scatter field. When 'flat_crossproduct', specifies the Cartesian\nproduct of the inputs, producing a job for every combination of the scattered\ninputs. The output arrays must be flattened to a single level, but otherwise\nlisted in the order that the input arrays are listed in the scatter field.\n",
+        "enum": [
+          "dotproduct",
+          "nested_crossproduct",
+          "flat_crossproduct"
+        ]
+      },
+      "cwl-CWLGraphItemBase": {
+        "type": "object",
+        "title": "CWLGraphItem",
+        "properties": {
+          "class": {
+            "type": "string",
+            "title": "Class",
+            "description": "CWL class specification. This is used to differentiate between single Application Package (AP)definitions and Workflow that chains multiple packages.",
+            "enum": [
+              "CommandLineTool",
+              "ExpressionTool",
+              "Workflow"
+            ]
+          },
+          "id": {
+            "$ref": "#/components/schemas/cwl-CWLIdentifier"
+          },
+          "intent": {
+            "$ref": "#/components/schemas/cwl-CWLIntent"
+          },
+          "requirements": {
+            "$ref": "#/components/schemas/cwl-CWLRequirements"
+          },
+          "hints": {
+            "$ref": "#/components/schemas/cwl-CWLHints"
+          },
+          "baseCommand": {
+            "$ref": "#/components/schemas/cwl-CWLCommand"
+          },
+          "arguments": {
+            "$ref": "#/components/schemas/cwl-CWLArguments"
+          },
+          "inputs": {
+            "$ref": "#/components/schemas/cwl-CWLInputsDefinition"
+          },
+          "outputs": {
+            "$ref": "#/components/schemas/cwl-CWLOutputsDefinition"
+          },
+          "scatter": {
+            "$ref": "#/components/schemas/cwl-CWLScatter"
+          },
+          "scatterMethod": {
+            "$ref": "#/components/schemas/cwl-CWLScatterMethod"
+          }
+        },
+        "required": [
+          "class",
+          "id",
+          "inputs",
+          "outputs"
+        ]
+      },
+      "cwl-CWLGraphItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLMetadata"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLDocumentation"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLGraphItemBase"
+          }
+        ],
+        "title": "CWLGraphItem"
+      },
+      "cwl-CWLGraphList": {
+        "type": "array",
+        "title": "CWLGraphList",
+        "description": "Graph definition that defines *exactly one* CWL application package represented as list. Multiple definitions simultaneously deployed is NOT supported currently.",
+        "items": {
+          "$ref": "#/components/schemas/cwl-CWLGraphItem"
+        },
+        "maxItems": 1,
+        "minItems": 1
+      },
+      "cwl-CWLGraphBase": {
+        "type": "object",
+        "properties": {
+          "$graph": {
+            "$ref": "#/components/schemas/cwl-CWLGraphList"
+          }
+        },
+        "required": [
+          "$graph"
+        ],
+        "title": "CWLGraphBase"
+      },
+      "cwl-LinkMergeMethod": {
+        "type": "string",
+        "enum": [
+          "merge_nested",
+          "merge_flattened"
+        ],
+        "title": "LinkMergeMethod"
+      },
+      "cwl-CWLWorkflowStepInput": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepInputBase"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepInputDefault"
+          }
+        ],
+        "title": "CWLWorkflowStepInput"
+      },
+      "cwl-CWLWorkflowNested": {
+        "description": "Same as 'CWLWorkflow', but 'cwlVersion' not repeated (only at root).",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLMetadata"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLDocumentation"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowClass"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowBase"
+          }
+        ],
+        "title": "CWLWorkflowNested"
+      },
+      "cwl-CWLWorkflowStepOutId": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/cwl-CWLIdentifier"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "additionalProperties": false,
+        "title": "CWLWorkflowStepOutId"
+      },
+      "cwl-IdentifierArray": {
+        "type": "array",
+        "title": "IdentifierArray",
+        "items": {
+          "$ref": "#/components/schemas/cwl-CWLTextPatternID"
+        },
+        "minItems": 1
+      },
+      "cwl-Scatter": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLTextPatternID"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-IdentifierArray"
+          }
+        ],
+        "title": "Scatter",
+        "description": "The scatter field specifies one or more input parameters which will be scattered.\n\nAn input parameter may be listed more than once. The declared type of each\ninput parameter implicitly becomes an array of items of the input parameter type.\nIf a parameter is listed more than once, it becomes a nested array. As a result,\nupstream parameters which are connected to scattered parameters must be arrays.\n\nAll output parameter types are also implicitly wrapped in arrays. Each job\nin the scatter results in an entry in the output array.\n\nIf any scattered parameter runtime value is an empty array, all outputs are\nset to empty arrays and no work is done for the step, according to applicable scattering rules.\n"
+      },
+      "cwl-ScatterMethod": {
+        "type": "string",
+        "title": "scatterMethod",
+        "description": "If 'scatter' declares more than one input parameter, 'scatterMethod'\ndescribes how to decompose the input into a discrete set of jobs.\n\n- dotproduct: specifies that each of the input arrays are aligned and\n  one element taken from each array to construct each job. It is an\n  error if all input arrays are not the same length.\n\n- nested_crossproduct: specifies the Cartesian product of the inputs, producing\n  a job for every combination of the scattered inputs. The output must be nested\n  arrays for each level of scattering, in the order that the input arrays\n  are listed in the 'scatter' field.\n\n- flat_crossproduct: specifies the Cartesian product of the inputs, producing a\n  job for every combination of the scattered inputs. The output arrays must be\n  flattened to a single level, but otherwise listed in the order that the input\n  arrays are listed in the 'scatter' field.\n",
+        "default": "dotproduct",
+        "enum": [
+          "dotproduct",
+          "nested_crossproduct",
+          "flat_crossproduct"
+        ]
+      },
+      "cwl-CWLWorkflowStepItem": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepId"
+          },
+          {
+            "$ref": "#/components/schemas/cwl-CWLWorkflowStepObject"
+          }
+        ],
+        "title": "CWLWorkflowStepItem"
       },
       "processes-dru-executionUnitBase": {
         "oneOf": [
@@ -4354,7 +7502,7 @@
                         ]
                       },
                       "value": {
-                        "$ref": "#/components/schemas/cwl-cwl-json-schema"
+                        "$ref": "#/components/schemas/cwl-CWL"
                       }
                     }
                   },
@@ -4374,7 +7522,8 @@
               }
             ]
           }
-        ]
+        ],
+        "title": "executionUnitBase"
       },
       "processes-dru-executionUnit": {
         "oneOf": [
@@ -4389,7 +7538,8 @@
               }
             ]
           }
-        ]
+        ],
+        "title": "executionUnit"
       },
       "processes-workflows-execute-workflows": {
         "allOf": [
@@ -4436,7 +7586,8 @@
               }
             }
           }
-        ]
+        ],
+        "title": "execute-workflows"
       },
       "processes-workflows-inputProcess": {
         "allOf": [
@@ -4449,7 +7600,8 @@
           {
             "$ref": "#/components/schemas/processes-workflows-execute-workflows"
           }
-        ]
+        ],
+        "title": "inputProcess"
       },
       "processes-workflows-value-workflows": {
         "oneOf": [
@@ -4459,7 +7611,8 @@
           {
             "type": "object"
           }
-        ]
+        ],
+        "title": "value-workflows"
       },
       "processes-workflows-qualifiedValue-workflows": {
         "allOf": [
@@ -4480,7 +7633,8 @@
               }
             }
           }
-        ]
+        ],
+        "title": "qualifiedValue-workflows"
       },
       "processes-workflows-outputSelection-workflows": {
         "type": "object",
@@ -4491,7 +7645,8 @@
           "$output": {
             "type": "string"
           }
-        }
+        },
+        "title": "outputSelection-workflows"
       },
       "geojson-FeatureCollection": {
         "title": "GeoJSON FeatureCollection",
@@ -4786,7 +7941,8 @@
             ],
             "default": "ogc-api-processes"
           }
-        ]
+        ],
+        "title": "processingEntityType"
       },
       "processes-job-management-headers": {
         "description": "Mapping of included or resolved HTTP headers names and values relevant for the job submission request.",
@@ -4794,7 +7950,8 @@
         "additionalProperties": {
           "type": "string",
           "nullable": true
-        }
+        },
+        "title": "headers"
       },
       "processes-job-management-jobDefinition": {
         "description": "Definition of the parameters of a submitted job.",
@@ -4868,7 +8025,8 @@
             }
           }
         },
-        "additionalProperties": true
+        "additionalProperties": true,
+        "title": "jobDefinition"
       },
       "records-core-roles": {
         "title": "Types or roles",
@@ -5092,7 +8250,8 @@
             "description": "Media type of the format.",
             "type": "string"
           }
-        }
+        },
+        "title": "format"
       },
       "records-core-theme": {
         "type": "object",
@@ -5142,7 +8301,8 @@
             "title": "Identifier of the vocabulary",
             "description": "An identifier for the knowledge organization system used to classify the resource.  It is recommended that the identifier be a resolvable URI.  The list of schemes used in a searchable catalog can be determined by inspecting the server's OpenAPI document or, if the server implements CQL2, by exposing a queryable (e.g. named `scheme`) and enumerating the list of schemes in the queryable's schema definition."
           }
-        }
+        },
+        "title": "theme"
       },
       "records-core-language": {
         "type": "object",
@@ -5459,7 +8619,8 @@
             "type": "string",
             "format": "date-time"
           }
-        }
+        },
+        "title": "collectionProperties"
       },
       "common-geodata-regularGrid": {
         "type": "object",

--- a/openapi/ogcapi-processes.yaml
+++ b/openapi/ogcapi-processes.yaml
@@ -129,6 +129,7 @@ components:
       # Common Workflow Language
       CWL:
          #$ref: 'https://w3id.org/cwl/v1.2/cwl-json-schema.yaml'
+         #$ref: 'schemas/cwl/cwl.yaml'  # alias
          $ref: 'schemas/cwl/cwl-json-schema.yaml#/$defs/CWL'
       cwltool_CUDARequirement:
          $ref: 'schemas/cwl/cwl-json-schema.yaml#/$defs/cwltool_CUDARequirement'

--- a/openapi/ogcapi-processes.yaml
+++ b/openapi/ogcapi-processes.yaml
@@ -129,7 +129,7 @@ components:
       # Common Workflow Language
       CWL:
          #$ref: 'https://w3id.org/cwl/v1.2/cwl-json-schema.yaml'
-         $ref: 'schemas/cwl/cwl.yaml'
+         $ref: 'schemas/cwl/cwl-json-schema.yaml#/$defs/CWL'
       cwltool_CUDARequirement:
          $ref: 'schemas/cwl/cwl-json-schema.yaml#/$defs/cwltool_CUDARequirement'
 

--- a/openapi/ogcapi-processes.yaml
+++ b/openapi/ogcapi-processes.yaml
@@ -129,7 +129,7 @@ components:
       # Common Workflow Language
       CWL:
          #$ref: 'https://w3id.org/cwl/v1.2/cwl-json-schema.yaml'
-         #$ref: 'schemas/cwl/cwl.yaml'  # alias
+         #$ref: 'schemas/cwl/cwl.yaml'  # alias, can use either one interchangeably
          $ref: 'schemas/cwl/cwl-json-schema.yaml#/$defs/CWL'
       cwltool_CUDARequirement:
          $ref: 'schemas/cwl/cwl-json-schema.yaml#/$defs/cwltool_CUDARequirement'

--- a/openapi/paths/processes-dru/operations/oDeploy.yaml
+++ b/openapi/paths/processes-dru/operations/oDeploy.yaml
@@ -19,15 +19,18 @@ requestBody:
     application/cwl:
       schema:
         #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-        $ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+        #$ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+        $ref: "../../../schemas/cwl/cwl.yaml"
     application/cwl+json:
       schema:
         #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-        $ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+        #$ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+        $ref: "../../../schemas/cwl/cwl.yaml"
     application/cwl+yaml:
       schema:
         #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-        $ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+        #$ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+        $ref: "../../../schemas/cwl/cwl.yaml"
 responses:
   201:
     $ref: "../../../responses/processes-dru/rProcessSummary.yaml"

--- a/openapi/paths/processes-dru/operations/oDeploy.yaml
+++ b/openapi/paths/processes-dru/operations/oDeploy.yaml
@@ -19,15 +19,15 @@ requestBody:
     application/cwl:
       schema:
         #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-        $ref: "../../../schemas/cwl/cwl.yaml"
+        $ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
     application/cwl+json:
       schema:
         #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-        $ref: "../../../schemas/cwl/cwl.yaml"
+        $ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
     application/cwl+yaml:
       schema:
         #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-        $ref: "../../../schemas/cwl/cwl.yaml"
+        $ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
 responses:
   201:
     $ref: "../../../responses/processes-dru/rProcessSummary.yaml"

--- a/openapi/paths/processes-dru/operations/oReplace.yaml
+++ b/openapi/paths/processes-dru/operations/oReplace.yaml
@@ -19,15 +19,18 @@ requestBody:
     application/cwl:
       schema:
         #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-        $ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+        #$ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+        $ref: "../../../schemas/cwl/cwl.yaml"
     application/cwl+json:
       schema:
         #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-        $ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+        #$ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+        $ref: "../../../schemas/cwl/cwl.yaml"
     application/cwl+yaml:
       schema:
         #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-        $ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+        #$ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+        $ref: "../../../schemas/cwl/cwl.yaml"
 responses:
   200:
     $ref: "../../../responses/processes-dru/rProcessSummary.yaml"

--- a/openapi/paths/processes-dru/operations/oReplace.yaml
+++ b/openapi/paths/processes-dru/operations/oReplace.yaml
@@ -19,15 +19,15 @@ requestBody:
     application/cwl:
       schema:
         #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-        $ref: "../../../schemas/cwl/cwl.yaml"
+        $ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
     application/cwl+json:
       schema:
         #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-        $ref: "../../../schemas/cwl/cwl.yaml"
+        $ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
     application/cwl+yaml:
       schema:
         #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-        $ref: "../../../schemas/cwl/cwl.yaml"
+        $ref: "../../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
 responses:
   200:
     $ref: "../../../responses/processes-dru/rProcessSummary.yaml"

--- a/openapi/paths/processes-dru/pPackage.yaml
+++ b/openapi/paths/processes-dru/pPackage.yaml
@@ -18,16 +18,16 @@ get:
             schema:
               #$ref: "https://raw.githubusercontent.com/common-workflow-lab/cwl-ts-auto/main/json_schemas/cwl_schema.yaml"
               #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-              $ref: "../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+              $ref: "../../schemas/cwl/cwl.yaml"
          application/cwl+json:
             schema:
               #$ref: "https://raw.githubusercontent.com/common-workflow-lab/cwl-ts-auto/main/json_schemas/cwl_schema.yaml"
               #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-              $ref: "../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+              $ref: "../../schemas/cwl/cwl.yaml"
          application/cwl+yaml:
             schema:
               #$ref: "https://raw.githubusercontent.com/common-workflow-lab/cwl-ts-auto/main/json_schemas/cwl_schema.yaml"
               #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-              $ref: "../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
+              $ref: "../../schemas/cwl/cwl.yaml"
      404:
         $ref: "../../responses/common-core/rNotFound.yaml"

--- a/openapi/paths/processes-dru/pPackage.yaml
+++ b/openapi/paths/processes-dru/pPackage.yaml
@@ -18,16 +18,16 @@ get:
             schema:
               #$ref: "https://raw.githubusercontent.com/common-workflow-lab/cwl-ts-auto/main/json_schemas/cwl_schema.yaml"
               #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-              $ref: "../../schemas/cwl/cwl.yaml"
+              $ref: "../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
          application/cwl+json:
             schema:
               #$ref: "https://raw.githubusercontent.com/common-workflow-lab/cwl-ts-auto/main/json_schemas/cwl_schema.yaml"
               #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-              $ref: "../../schemas/cwl/cwl.yaml"
+              $ref: "../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
          application/cwl+yaml:
             schema:
               #$ref: "https://raw.githubusercontent.com/common-workflow-lab/cwl-ts-auto/main/json_schemas/cwl_schema.yaml"
               #$ref: "https://w3id.org/cwl/v1.2/cwl-json-schema.yaml"
-              $ref: "../../schemas/cwl/cwl.yaml"
+              $ref: "../../schemas/cwl/cwl-json-schema.yaml#/$defs/CWL"
      404:
         $ref: "../../responses/common-core/rNotFound.yaml"

--- a/openapi/schemas/cwl/cwl.yaml
+++ b/openapi/schemas/cwl/cwl.yaml
@@ -1,1 +1,4 @@
+# this schema is preserved for cross-reference backward-compatibility
+# for references within OpenAPI, use explicit reference to below $ref value and component instead
+# this avoids creating duplicate entries for which tools like redocly tries to dinstinguish with unnecessary suffixes
 $ref: './cwl-json-schema.yaml#/$defs/CWL'

--- a/openapi/schemas/cwl/cwl.yaml
+++ b/openapi/schemas/cwl/cwl.yaml
@@ -1,4 +1,4 @@
-# this schema is preserved for cross-reference backward-compatibility
-# for references within OpenAPI, use explicit reference to below $ref value and component instead
+# this schema can be used to more easily refer to the top-most CWL schema directly
+# for references within OpenAPI, use explicit reference to below local CWL schema rather than the remote one
 # this avoids creating duplicate entries for which tools like redocly tries to dinstinguish with unnecessary suffixes
 $ref: './cwl-json-schema.yaml#/$defs/CWL'

--- a/openapi/schemas/processes-dru/executionUnitBase.yaml
+++ b/openapi/schemas/processes-dru/executionUnitBase.yaml
@@ -27,7 +27,8 @@ oneOf:
             enum:
               - application/cwl
           value:
-            $ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
+            #$ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
+            $ref: "../cwl/cwl-json-schema.yaml#/$defs/CWL"
       - description: |-
           The execution unit is not Docker/OCI or CWL and cannot be properly
           described via the "mediaType" property of a qualified value 

--- a/openapi/schemas/processes-dru/executionUnitBase.yaml
+++ b/openapi/schemas/processes-dru/executionUnitBase.yaml
@@ -28,7 +28,8 @@ oneOf:
               - application/cwl
           value:
             #$ref: "https://raw.githubusercontent.com/common-workflow-language/cwl-v1.2/main/json-schema/cwl.yaml"
-            $ref: "../cwl/cwl-json-schema.yaml#/$defs/CWL"
+            #$ref: "../cwl/cwl-json-schema.yaml#/$defs/CWL"
+            $ref: "../cwl/cwl.yaml"
       - description: |-
           The execution unit is not Docker/OCI or CWL and cannot be properly
           described via the "mediaType" property of a qualified value 


### PR DESCRIPTION
## Changes

- replaced the explicit CWL schema URI in *Part 3: Workflows & Chaining* causing duplicate CWL definitions from local schema used by *Part 2: DRU*
- improved the redocly plugin logic to properly include all CWL subschemas
- added `title` injection (if not already provided) to nicely render the schemas in Swagger-UI (such that the bundle's dir-prefix to manage schema-name conflicts is not shown)

Recent update to redocly slightly tweaked the behaviour (https://github.com/Redocly/redocly-cli/releases/tag/%40redocly%2Fcli%402.45.0), which causes the auto-update bundle diffs seen in other active PRs.

The result is now properly obtained as shown below.

## Result

<img width="1375" height="1116" alt="image" src="https://github.com/user-attachments/assets/4577d9c8-a010-4ab4-8f17-54830924e9a6" />
