### PR TITLE
Part 5: add headers to make it easier to find and reference large PROV examples

### DIFF
--- a/extensions/deploy_replace_undeploy/standard/sections/clause_3_references.adoc
+++ b/extensions/deploy_replace_undeploy/standard/sections/clause_3_references.adoc
@@ -2,12 +2,12 @@
 [bibliography]
 == References
 
-* [[[OAProc-1,OGC 18-062]]] Pross, B.: OGC 18-062, *OGC API - Processes - Part 1: Core*
+* [[[OAProc-1,OGC 18-062]]], Pross, B.: OGC 18-062, *OGC API - Processes - Part 1: Core*
 
 * [[[OAFeat-1,OGC 17-069r3]]], OGC 17-069r3, OGC API - Features - Part 1: Core
 
 * [[[OAFeat-4,OGC 20-004r1]]], OGC 20-004-r1 OGC API - Features - Part 4: Create, Replace, Update and Delete
 
-* [[rfc6902,IETF RFC 6902]] Bryan, P., Nottingham, M.: IETF RFC 6902, *JavaScript Object Notation (JSON) Patch*, 2013 http://tools.ietf.org/rfc/rfc6902.txt
+* [[[rfc6902,IETF RFC 6902]]], Bryan, P., Nottingham, M.: IETF RFC 6902, *JavaScript Object Notation (JSON) Patch*, 2013 http://tools.ietf.org/rfc/rfc6902.txt
 
-* [[rfc2387,IETF RFC 2387]] E. Levinson: IETF RFC 2387, *The MIME Multipart/Related Content-type*, 1998 http://tools.ietf.org/rfc/rfc2387.txt
+* [[[rfc2387,IETF RFC 2387]]], E. Levinson: IETF RFC 2387, *The MIME Multipart/Related Content-type*, 1998 http://tools.ietf.org/rfc/rfc2387.txt

--- a/extensions/job_management/standard/sections/clause_3_references.adoc
+++ b/extensions/job_management/standard/sections/clause_3_references.adoc
@@ -10,4 +10,4 @@
 
 * [[[OAFeat-1,OGC 17-069r3]]], OGC Portele C.: 17-069r3, *OGC API - Features - Part 1: Core*
 
-* [[rfc6902,IETF RFC 6902]] Bryan, P., Nottingham, M.: IETF RFC 6902, *JavaScript Object Notation (JSON) Patch*, 2013 http://tools.ietf.org/rfc/rfc6902.txt
+* [[[rfc6902,IETF RFC 6902]]], Bryan, P., Nottingham, M.: IETF RFC 6902, *JavaScript Object Notation (JSON) Patch*, 2013 http://tools.ietf.org/rfc/rfc6902.txt

--- a/extensions/provenance/standard/26-038.adoc
+++ b/extensions/provenance/standard/26-038.adoc
@@ -15,6 +15,9 @@
 :editor: Francis Charette-Migneault, Gérald Fenoy
 :mn-document-class: ogc
 :mn-output-extensions: xml,html,doc,pdf
+:toc:
+:toc-placement!:
+:toclevels: 7
 
 ////
 Make sure to complete each included document

--- a/extensions/provenance/standard/recommendations/provenance/job-prov/PER_content-negotiation.adoc
+++ b/extensions/provenance/standard/recommendations/provenance/job-prov/PER_content-negotiation.adoc
@@ -15,6 +15,7 @@ The server MAY support the additional content type `application/ld+json`
 for link:https://www.w3.org/submissions/prov-jsonld/[PROV-JSONLD] as a <<W3C-PROV>> representation
 in link:https://www.w3.org/TR/json-ld/[JSON-LD], where the contents respect the
 link:https://openprovenance.org/prov-jsonld/schema.json[PROV-JSONLD] schema.
+An example of such representation is provided in <<example-provenance-job-prov-jsonld>>.
 --
 
 [.component,class=part]
@@ -23,6 +24,7 @@ The server MAY support the additional content type `application/provenace+xml`
 (and optionally `application/xml` or `text/xml` as acceptable aliases)
 for link:https://www.w3.org/TR/prov-xml/[PROV-XML] as a <<W3C-PROV>> representation
 in XML using namespaces defined by the link:https://www.w3.org/ns/prov.xsd[PROV-XML] schema.
+An example of such representation is provided in <<example-provenance-job-prov-xml>>.
 --
 
 [.component,class=part]
@@ -30,6 +32,7 @@ in XML using namespaces defined by the link:https://www.w3.org/ns/prov.xsd[PROV-
 The server MAY support the additional content type `text/provenance-notation`
 for link:https://www.w3.org/TR/prov-n/[PROV-N] as a human-readable provenance notation
 of the link:http://www.w3.org/TR/prov-dm/[PROV-DM] data model.
+An example of such representation is provided in <<example-provenance-job-prov-n>>.
 --
 
 [.component,class=part]
@@ -37,6 +40,7 @@ of the link:http://www.w3.org/TR/prov-dm/[PROV-DM] data model.
 The server MAY support the additional content type `application/n-triples`
 for PROV-NT as link:https://www.w3.org/TR/n-triples/[N-Triples RDF]
 using the link:https://www.w3.org/TR/prov-o/[PROV-O] RDF ontology.
+An example of such representation is provided in <<example-provenance-job-prov-nt>>.
 --
 
 [.component,class=part]
@@ -44,6 +48,7 @@ using the link:https://www.w3.org/TR/prov-o/[PROV-O] RDF ontology.
 The server MAY support the additional content type `text/turtle`
 for PROV-TURTLE as link:https://www.w3.org/TR/rdf12-turtle/[Turtle RDF]
 using the link:https://www.w3.org/TR/prov-o/[PROV-O] RDF ontology.
+An example of such representation is provided in <<example-provenance-job-prov-turtle>>.
 --
 
 [.component,class=part]

--- a/extensions/provenance/standard/requirements/provenance/job-prov/REQ_response.adoc
+++ b/extensions/provenance/standard/requirements/provenance/job-prov/REQ_response.adoc
@@ -13,6 +13,7 @@ A successful execution of the operation SHALL be reported as a response with a H
 --
 By default or if explicitly negotiated as such, the response SHALL contains a JSON document that conforms to the
 link:https://www.w3.org/submissions/prov-json/schema[W3C PROV-JSON] schema.
+An example of such representation is provided in <<example-provenance-job-prov-json>>.
 --
 
 [.component,class=part]

--- a/extensions/provenance/standard/sections/annex_examples.adoc
+++ b/extensions/provenance/standard/sections/annex_examples.adoc
@@ -7,12 +7,18 @@ link:https://github.com/crim-ca/weaver[crim-ca/weaver] server implementation, fo
 runtime encoded in Common Workflow Language (CWL). This standard does not require these specific tools
 and provides the examples for illustration purposes only.
 
+[[prov-content-examples-prov-json]]
+==== Example of Provenance in PROV-JSON representation
+
 [[example-provenance-job-prov-json]]
 .Example: PROV-JSON
 [source,json]
 ----
 include::../examples/job_prov.json[]
 ----
+
+[[prov-content-examples-prov-jsonld]]
+==== Example of Provenance in PROV-JSONLD representation
 
 [[example-provenance-job-prov-jsonld]]
 .Example: PROV-JSONLD
@@ -21,6 +27,9 @@ include::../examples/job_prov.json[]
 include::../examples/job_prov.jsonld[]
 ----
 
+[[prov-content-examples-prov-xml]]
+==== Example of Provenance in PROV-XML representation
+
 [[example-provenance-job-prov-xml]]
 .Example: PROV-XML
 [source,xml]
@@ -28,12 +37,18 @@ include::../examples/job_prov.jsonld[]
 include::../examples/job_prov.xml[]
 ----
 
-[[example-provenance-job-prov-provn]]
+[[prov-content-examples-prov-n]]
+==== Example of Provenance in PROV-N representation
+
+[[example-provenance-job-prov-n]]
 .Example: PROV-N
 [source,text]
 ----
 include::../examples/job_prov.provn[]
 ----
+
+[[prov-content-examples-prov-nt]]
+==== Example of Provenance in PROV-NT representation
 
 [[example-provenance-job-prov-nt]]
 .Example: PROV-NT
@@ -42,7 +57,10 @@ include::../examples/job_prov.provn[]
 include::../examples/job_prov.nt[]
 ----
 
-[[example-provenance-job-prov-ttl]]
+[[prov-content-examples-prov-turtle]]
+==== Example of Provenance in PROV-TURTLE representation
+
+[[example-provenance-job-prov-turtle]]
 .Example: PROV-TURTLE
 [source,turtle]
 ----

--- a/extensions/provenance/standard/sections/annex_examples.adoc
+++ b/extensions/provenance/standard/sections/annex_examples.adoc
@@ -1,5 +1,5 @@
 [[prov-content-examples]]
-=== Examples
+== Examples
 
 NOTE: Following examples were generated using a combination of
 link:https://github.com/common-workflow-language/cwlprov[cwlprov] and additional metadata defined by
@@ -8,7 +8,7 @@ runtime encoded in Common Workflow Language (CWL). This standard does not requir
 and provides the examples for illustration purposes only.
 
 [[prov-content-examples-prov-json]]
-==== Example of Provenance in PROV-JSON representation
+=== Example of Provenance in PROV-JSON representation
 
 [[example-provenance-job-prov-json]]
 .Example: PROV-JSON
@@ -18,7 +18,7 @@ include::../examples/job_prov.json[]
 ----
 
 [[prov-content-examples-prov-jsonld]]
-==== Example of Provenance in PROV-JSONLD representation
+=== Example of Provenance in PROV-JSONLD representation
 
 [[example-provenance-job-prov-jsonld]]
 .Example: PROV-JSONLD
@@ -28,7 +28,7 @@ include::../examples/job_prov.jsonld[]
 ----
 
 [[prov-content-examples-prov-xml]]
-==== Example of Provenance in PROV-XML representation
+=== Example of Provenance in PROV-XML representation
 
 [[example-provenance-job-prov-xml]]
 .Example: PROV-XML
@@ -38,7 +38,7 @@ include::../examples/job_prov.xml[]
 ----
 
 [[prov-content-examples-prov-n]]
-==== Example of Provenance in PROV-N representation
+=== Example of Provenance in PROV-N representation
 
 [[example-provenance-job-prov-n]]
 .Example: PROV-N
@@ -48,7 +48,7 @@ include::../examples/job_prov.provn[]
 ----
 
 [[prov-content-examples-prov-nt]]
-==== Example of Provenance in PROV-NT representation
+=== Example of Provenance in PROV-NT representation
 
 [[example-provenance-job-prov-nt]]
 .Example: PROV-NT
@@ -58,7 +58,7 @@ include::../examples/job_prov.nt[]
 ----
 
 [[prov-content-examples-prov-turtle]]
-==== Example of Provenance in PROV-TURTLE representation
+=== Example of Provenance in PROV-TURTLE representation
 
 [[example-provenance-job-prov-turtle]]
 .Example: PROV-TURTLE

--- a/extensions/provenance/standard/sections/clause_3_references.adoc
+++ b/extensions/provenance/standard/sections/clause_3_references.adoc
@@ -2,12 +2,12 @@
 [bibliography]
 == References
 
-* [[[OAProc-1,OGC 18-062]]] Pross, B., Vretanos, P.: OGC 18-062, *OGC API - Processes - Part 1: Core*
+* [[[OAProc-1,OGC 18-062]]], Pross, B., Vretanos, P.: OGC 18-062, *OGC API - Processes - Part 1: Core*
 
-* [[[OAProc-2,OGC 20-044]]] Vretanos, P., Fenoy, G.: OGC 20-044, *OGC API - Processes - Part 2: Deploy, Replace, Undeploy*
+* [[[OAProc-2,OGC 20-044]]], Vretanos, P., Fenoy, G.: OGC 20-044, *OGC API - Processes - Part 2: Deploy, Replace, Undeploy*
 
-* [[[OAProc-3,OGC 21-009]]] Jacovella-St-Louis J.: OGC 21-009, *OGC API - Processes - Part 3: Workflows and Chaining*
+* [[[OAProc-3,OGC 21-009]]], Jacovella-St-Louis J.: OGC 21-009, *OGC API - Processes - Part 3: Workflows and Chaining*
 
-* [[[OAProc-4,OGC 24-051]]] Fenoy, G., Charette-Migneault, F.: OGC 24-051, *OGC API - Processes - Part 4: Job Management*
+* [[[OAProc-4,OGC 24-051]]], Fenoy, G., Charette-Migneault, F.: OGC 24-051, *OGC API - Processes - Part 4: Job Management*
 
-* [[rfc6902,IETF RFC 6902]] Bryan, P., Nottingham, M.: IETF RFC 6902, *JavaScript Object Notation (JSON) Patch*, 2013 http://tools.ietf.org/rfc/rfc6902.txt
+* [[[rfc6902,IETF RFC 6902]]], Bryan, P., Nottingham, M.: IETF RFC 6902, *JavaScript Object Notation (JSON) Patch*, 2013 http://tools.ietf.org/rfc/rfc6902.txt


### PR DESCRIPTION

## Before
<img width="500" alt="{C14E6BE9-D7F3-4750-90D9-B89C1A93485C}" src="https://github.com/user-attachments/assets/d5d86f26-2da4-40cd-a908-78e3ab9ac127" />

## After

<img width="500" alt="{62F1B2F0-19A5-441A-9183-A1C7D9BEEDFC}" src="https://github.com/user-attachments/assets/78ac3233-6de8-4ad0-b17c-e1111388484f" />

