### PR TITLE
Add outputs schema

### DIFF
--- a/core/requirements/core/REQ_job-results-param-outputs.adoc
+++ b/core/requirements/core/REQ_job-results-param-outputs.adoc
@@ -6,5 +6,7 @@ identifier:: /req/core/job-results-param-outputs
 
 The operation at the `/jobs/{jobID}/results` endpoint SHALL support a parameter `outputs` with the following characteristics (using an OpenAPI Specification fragment):
 
-link:../../openapi/schemas/processes-core/outputs.yaml[role=include]
-
+[source,yaml]
+----
+include::../../openapi/schemas/processes-core/outputs.yaml[role=include]
+----

--- a/core/requirements/core/REQ_job-results-param-outputs.adoc
+++ b/core/requirements/core/REQ_job-results-param-outputs.adoc
@@ -6,16 +6,5 @@ identifier:: /req/core/job-results-param-outputs
 
 The operation at the `/jobs/{jobID}/results` endpoint SHALL support a parameter `outputs` with the following characteristics (using an OpenAPI Specification fragment):
 
-[source,yaml]
-----
-name: outputs
-in: query
-required: false
-schema:
-  type: array
-  items:
-    type: string
-style: form
-explode: false
-----
-====
+link:../../openapi/schemas/processes-core/outputs.yaml[role=include]
+

--- a/openapi/parameters/processes-core/outputs.yaml
+++ b/openapi/parameters/processes-core/outputs.yaml
@@ -1,0 +1,9 @@
+name: outputs
+in: query
+required: false
+schema:
+  type: array
+  items:
+    type: string
+style: form
+explode: false


### PR DESCRIPTION
Create the required outputs schema for the parameters in processes-core.

Use this schema from the `/req/core/job-results-param-outputs` requirement.