### PR TITLE
fix broken ref failing metanorma build

### DIFF
--- a/core/requirements/core/REQ_job-results-param-outputs.adoc
+++ b/core/requirements/core/REQ_job-results-param-outputs.adoc
@@ -8,5 +8,7 @@ The operation at the `/jobs/{jobID}/results` endpoint SHALL support a parameter 
 
 [source,yaml]
 ----
-include::../../openapi/schemas/processes-core/outputs.yaml[role=include]
+include::../../../openapi/parameters/processes-core/outputs.yaml[]
 ----
+
+====


### PR DESCRIPTION
@gfenoy FYI

Metanorma raises during build, so the old render is produced on https://docs.ogc.org/DRAFTS/18-062r3.html